### PR TITLE
feat: Across adapter

### DIFF
--- a/crates/adapters/src/across_adapter.rs
+++ b/crates/adapters/src/across_adapter.rs
@@ -186,20 +186,11 @@ impl AcrossRoute {
 			reason: format!("Invalid destination asset in Across route: {}", e),
 		})?;
 
-		// Create AssetRoute with symbols and metadata
-		let metadata = serde_json::json!({
-			"isNative": self.is_native,
-			"source": "across-api",
-			"originChainId": self.origin_chain_id,
-			"destinationChainId": self.destination_chain_id
-		});
-
-		Ok(AssetRoute::with_symbols_and_metadata(
+		Ok(AssetRoute::with_symbols(
 			origin_asset,
 			self.origin_token_symbol.clone(),
 			destination_asset,
 			self.destination_token_symbol.clone(),
-			metadata,
 		))
 	}
 }
@@ -697,14 +688,6 @@ mod tests {
 			asset_route.destination_token_symbol,
 			Some("USDC".to_string())
 		);
-
-		// Verify metadata
-		assert!(asset_route.metadata.is_some());
-		let metadata = asset_route.metadata.clone().unwrap();
-		assert_eq!(metadata["isNative"], false);
-		assert_eq!(metadata["source"], "across-api");
-		assert_eq!(metadata["originChainId"], 1);
-		assert_eq!(metadata["destinationChainId"], 137);
 
 		// Verify route properties
 		assert!(asset_route.is_cross_chain());

--- a/crates/adapters/src/across_adapter.rs
+++ b/crates/adapters/src/across_adapter.rs
@@ -1,0 +1,1145 @@
+//! Across adapter implementation
+//!
+//! This adapter uses an optimized client cache for connection pooling and keep-alive.
+//! Submission and tracking of orders are not supported by this adapter.
+
+use async_trait::async_trait;
+use oif_types::adapters::AdapterQuote;
+use oif_types::{Adapter, Asset, GetQuoteRequest, GetQuoteResponse, Network, SolverRuntimeConfig};
+use oif_types::{AdapterError, AdapterResult, SolverAdapter};
+use reqwest::{
+	header::{HeaderMap, HeaderValue},
+	Client,
+};
+use serde_json;
+use std::{collections::HashSet, str::FromStr, sync::Arc};
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::client_cache::{ClientCache, ClientConfig};
+
+// ================================
+// ACROSS API MODELS
+// ================================
+
+/// Across available route response
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcrossRoute {
+	/// Origin chain ID
+	pub origin_chain_id: u64,
+	/// Destination chain ID  
+	pub destination_chain_id: u64,
+	/// Origin token contract address
+	pub origin_token: String,
+	/// Destination token contract address
+	pub destination_token: String,
+	/// Origin token symbol
+	pub origin_token_symbol: String,
+	/// Destination token symbol
+	pub destination_token_symbol: String,
+	/// Whether the origin token is a native token
+	pub is_native: bool,
+}
+
+/// Across suggested fees response
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcrossQuoteResponse {
+	/// Estimated fill time in seconds
+	pub estimated_fill_time_sec: u64,
+	/// Capital fee percentage
+	pub capital_fee_pct: String,
+	/// Capital fee total
+	pub capital_fee_total: String,
+	/// Relay gas fee percentage
+	pub relay_gas_fee_pct: String,
+	/// Relay gas fee total
+	pub relay_gas_fee_total: String,
+	/// Relay fee percentage
+	pub relay_fee_pct: String,
+	/// Relay fee total
+	pub relay_fee_total: String,
+	/// LP fee percentage
+	pub lp_fee_pct: String,
+	/// Timestamp
+	pub timestamp: String,
+	/// Whether amount is too low
+	pub is_amount_too_low: bool,
+	/// Quote block number
+	pub quote_block: String,
+	/// Exclusive relayer address
+	pub exclusive_relayer: String,
+	/// Exclusivity deadline timestamp
+	pub exclusivity_deadline: u64,
+	/// Spoke pool address
+	pub spoke_pool_address: String,
+	/// Destination spoke pool address
+	pub destination_spoke_pool_address: String,
+	/// Total relay fee breakdown
+	pub total_relay_fee: AcrossFeeBand,
+	/// Relayer capital fee breakdown
+	pub relayer_capital_fee: AcrossFeeBand,
+	/// Relayer gas fee breakdown
+	pub relayer_gas_fee: AcrossFeeBand,
+	/// LP fee breakdown
+	pub lp_fee: AcrossFeeBand,
+	/// Deposit limits
+	pub limits: AcrossLimits,
+	/// Fill deadline timestamp
+	pub fill_deadline: String,
+	/// Output amount
+	pub output_amount: String,
+	/// Input token details
+	pub input_token: AcrossToken,
+	/// Output token details
+	pub output_token: AcrossToken,
+	/// Quote ID
+	pub id: String,
+}
+
+/// Across fee breakdown
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AcrossFeeBand {
+	/// Fee percentage
+	pub pct: String,
+	/// Fee total amount
+	pub total: String,
+}
+
+/// Across deposit limits
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcrossLimits {
+	/// Minimum deposit amount
+	pub min_deposit: String,
+	/// Maximum deposit amount
+	pub max_deposit: String,
+	/// Maximum instant deposit amount
+	pub max_deposit_instant: String,
+	/// Maximum short delay deposit amount
+	pub max_deposit_short_delay: String,
+	/// Recommended instant deposit amount
+	pub recommended_deposit_instant: String,
+}
+
+/// Across token information
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AcrossToken {
+	/// Token contract address
+	pub address: String,
+	/// Token symbol
+	pub symbol: String,
+	/// Token decimals
+	pub decimals: u8,
+	/// Chain ID
+	pub chain_id: u64,
+}
+
+impl AcrossRoute {
+	/// Convert Across route to internal Asset models
+	/// Returns a tuple of (origin_asset, destination_asset)
+	pub fn to_assets(&self) -> AdapterResult<(Asset, Asset)> {
+		let origin_chain_id = self.origin_chain_id;
+		let destination_chain_id = self.destination_chain_id;
+
+		// Create origin asset
+		let origin_asset = Asset::new(
+			self.origin_token.clone(),
+			self.origin_token_symbol.clone(),
+			self.origin_token_symbol.clone(), // Use symbol as name for now
+			18, // Default to 18 decimals, could be improved with token registry
+			origin_chain_id,
+		);
+
+		// Create destination asset
+		let destination_asset = Asset::new(
+			self.destination_token.clone(),
+			self.destination_token_symbol.clone(),
+			self.destination_token_symbol.clone(), // Use symbol as name for now
+			18, // Default to 18 decimals, could be improved with token registry
+			destination_chain_id,
+		);
+
+		Ok((origin_asset, destination_asset))
+	}
+}
+
+/// Client strategy for the Across adapter
+#[derive(Debug)]
+enum ClientStrategy {
+	/// Use optimized client cache for connection pooling and reuse
+	Cached(ClientCache),
+	/// Create clients on-demand with no caching
+	OnDemand,
+}
+
+/// Across adapter for cross-chain bridge quotes
+#[derive(Debug)]
+pub struct AcrossAdapter {
+	config: Adapter,
+	client_strategy: ClientStrategy,
+}
+
+#[allow(dead_code)]
+impl AcrossAdapter {
+	/// Create a new Across adapter with optimized client caching (recommended)
+	///
+	/// This constructor provides optimal performance with connection pooling,
+	/// keep-alive optimization, and automatic TTL management.
+	pub fn new(config: Adapter) -> AdapterResult<Self> {
+		Self::with_cache(config, ClientCache::for_adapter())
+	}
+
+	/// Create Across adapter with custom client cache
+	///
+	/// Allows using a custom cache configuration for specific performance requirements
+	/// or testing scenarios.
+	pub fn with_cache(config: Adapter, cache: ClientCache) -> AdapterResult<Self> {
+		Ok(Self {
+			config,
+			client_strategy: ClientStrategy::Cached(cache),
+		})
+	}
+
+	/// Create Across adapter without client caching
+	///
+	/// Creates clients on-demand for each request. Simpler but less efficient
+	/// than the cached approach.
+	pub fn without_cache(config: Adapter) -> AdapterResult<Self> {
+		Ok(Self {
+			config,
+			client_strategy: ClientStrategy::OnDemand,
+		})
+	}
+
+	/// Create a new HTTP client with Across headers and specified timeout
+	fn create_client(solver_config: &SolverRuntimeConfig) -> AdapterResult<Arc<reqwest::Client>> {
+		let mut headers = HeaderMap::new();
+		headers.insert("Content-Type", HeaderValue::from_static("application/json"));
+		headers.insert("User-Agent", HeaderValue::from_static("OIF-Aggregator/1.0"));
+		headers.insert("X-Adapter-Type", HeaderValue::from_static("Across-v1"));
+		headers.insert("Accept", HeaderValue::from_static("application/json"));
+
+		// Add custom headers from the solver config
+		if let Some(solver_headers) = &solver_config.headers {
+			for (key, value) in solver_headers {
+				if let (Ok(header_name), Ok(header_value)) = (
+					reqwest::header::HeaderName::from_str(key),
+					HeaderValue::from_str(value),
+				) {
+					headers.insert(header_name, header_value);
+				}
+			}
+		}
+
+		let client = Client::builder()
+			.default_headers(headers)
+			.build()
+			.map_err(AdapterError::HttpError)?;
+
+		Ok(Arc::new(client))
+	}
+
+	/// Get an HTTP client for the given solver configuration
+	fn get_client(
+		&self,
+		solver_config: &SolverRuntimeConfig,
+	) -> AdapterResult<Arc<reqwest::Client>> {
+		match &self.client_strategy {
+			ClientStrategy::Cached(cache) => {
+				let client_config = ClientConfig::from(solver_config);
+				cache.get_client(&client_config)
+			},
+			ClientStrategy::OnDemand => Self::create_client(solver_config),
+		}
+	}
+
+	/// Create default Across adapter instance with optimization
+	pub fn with_default_config() -> AdapterResult<Self> {
+		let config = Adapter::new(
+			"across-v1".to_string(),
+			"Across v1 Protocol".to_string(),
+			"Across v1 Adapter".to_string(),
+			"1.0.0".to_string(),
+		);
+
+		Self::new(config)
+	}
+
+	/// Convert Across quote response to internal adapter quote format
+	fn convert_across_quote_to_adapter_quote(
+		&self,
+		across_quote: AcrossQuoteResponse,
+		request: &GetQuoteRequest,
+		_config: &SolverRuntimeConfig,
+	) -> AdapterResult<AdapterQuote> {
+		use oif_types::adapters::{AdapterQuote, QuoteDetails};
+
+		// Generate unique quote ID
+		let quote_id = Uuid::new_v4().to_string();
+
+		// Create quote details from the request structure
+		let details = QuoteDetails {
+			available_inputs: request.available_inputs.clone(),
+			requested_outputs: request.requested_outputs.clone(),
+		};
+
+		// Parse timestamp for valid_until
+		let valid_until = across_quote.timestamp.parse::<u64>().ok();
+
+		let metadata = serde_json::json!({
+			"across": across_quote
+		});
+
+		Ok(AdapterQuote {
+			orders: vec![], // EIP-712 orders are not supported for Across
+			details,
+			valid_until,
+			eta: Some(across_quote.estimated_fill_time_sec),
+			quote_id,
+			provider: format!("Across Protocol v{}", self.config.version),
+			metadata: Some(metadata),
+		})
+	}
+}
+
+#[async_trait]
+impl SolverAdapter for AcrossAdapter {
+	fn adapter_info(&self) -> &Adapter {
+		&self.config
+	}
+
+	async fn get_quotes(
+		&self,
+		request: &GetQuoteRequest,
+		config: &SolverRuntimeConfig,
+	) -> AdapterResult<GetQuoteResponse> {
+		debug!(
+			"Across adapter getting quotes for {} inputs and {} outputs via solver: {}",
+			request.available_inputs.len(),
+			request.requested_outputs.len(),
+			config.solver_id
+		);
+
+		// Validate request - Across adapter currently supports single input/output
+		if request.available_inputs.len() != 1 {
+			return Err(AdapterError::InvalidResponse {
+				reason: "Across adapter currently supports only single input".to_string(),
+			});
+		}
+		if request.requested_outputs.len() != 1 {
+			return Err(AdapterError::InvalidResponse {
+				reason: "Across adapter currently supports only single output".to_string(),
+			});
+		}
+
+		let input = &request.available_inputs[0];
+		let output = &request.requested_outputs[0];
+
+		// Extract chain IDs and addresses from InteropAddress
+		let input_chain_id =
+			input
+				.asset
+				.extract_chain_id()
+				.map_err(|e| AdapterError::InvalidResponse {
+					reason: format!("Invalid input asset chain ID: {}", e),
+				})?;
+		let input_token = input.asset.extract_address();
+
+		let output_chain_id =
+			output
+				.asset
+				.extract_chain_id()
+				.map_err(|e| AdapterError::InvalidResponse {
+					reason: format!("Invalid output asset chain ID: {}", e),
+				})?;
+		let output_token = output.asset.extract_address();
+
+		// Build query parameters for Across API
+		let client = self.get_client(config)?;
+		let quote_url = format!("{}/suggested-fees", config.endpoint);
+
+		debug!(
+			"Fetching Across quote from {} (solver: {}) - {}:{} -> {}:{}",
+			quote_url, config.solver_id, input_chain_id, input_token, output_chain_id, output_token
+		);
+
+		// Make the quote request
+		let response = client
+			.get(&quote_url)
+			.query(&[
+				("inputToken", input_token.as_str()),
+				("outputToken", output_token.as_str()),
+				("originChainId", &input_chain_id.to_string()),
+				("destinationChainId", &output_chain_id.to_string()),
+				("amount", &input.amount.to_string()),
+			])
+			.send()
+			.await
+			.map_err(AdapterError::HttpError)?;
+
+		if !response.status().is_success() {
+			return Err(AdapterError::InvalidResponse {
+				reason: format!(
+					"Across quote endpoint returned status {}",
+					response.status()
+				),
+			});
+		}
+
+		// Parse the JSON response
+		let across_quote: AcrossQuoteResponse =
+			response
+				.json()
+				.await
+				.map_err(|e| AdapterError::InvalidResponse {
+					reason: format!("Failed to parse Across quote response: {}", e),
+				})?;
+
+		// Check if amount is too low
+		if across_quote.is_amount_too_low {
+			return Err(AdapterError::InvalidResponse {
+				reason: format!(
+					"Amount {} is below minimum deposit of {}",
+					input.amount, across_quote.limits.min_deposit
+				),
+			});
+		}
+
+		// Convert Across response to internal quote format
+		let quote = self.convert_across_quote_to_adapter_quote(across_quote, request, config)?;
+
+		debug!(
+			"Across adapter successfully fetched quote {} for solver {}",
+			quote.quote_id, config.solver_id
+		);
+
+		Ok(GetQuoteResponse {
+			quotes: vec![quote],
+		})
+	}
+
+	async fn health_check(&self, config: &SolverRuntimeConfig) -> AdapterResult<bool> {
+		debug!(
+			"Across adapter health check for solver: {}",
+			config.solver_id
+		);
+
+		let client = self.get_client(config)?;
+		let routes_url = format!("{}/available-routes", config.endpoint);
+
+		debug!(
+			"Performing Across adapter health check at {} (solver: {})",
+			routes_url, config.solver_id
+		);
+
+		// Make a lightweight request to the routes endpoint
+		let response = client.get(&routes_url).send().await.map_err(|e| {
+			warn!(
+				"Across adapter health check failed for solver {}: HTTP error - {}",
+				config.solver_id, e
+			);
+			AdapterError::HttpError(e)
+		})?;
+
+		// Check if the response status indicates the service is healthy
+		let is_healthy = response.status().is_success();
+
+		if is_healthy {
+			// Optionally verify the response contains valid JSON
+			match response.json::<Vec<AcrossRoute>>().await {
+				Ok(routes) => {
+					debug!(
+						"Across adapter health check passed for solver {}: {} routes available",
+						config.solver_id,
+						routes.len()
+					);
+					Ok(true)
+				},
+				Err(e) => {
+					warn!(
+						"Across adapter health check failed for solver {}: Invalid JSON response - {}",
+						config.solver_id, e
+					);
+					Ok(false)
+				},
+			}
+		} else {
+			warn!(
+				"Across adapter health check failed for solver {}: HTTP status {}",
+				config.solver_id,
+				response.status()
+			);
+			Ok(false)
+		}
+	}
+
+	async fn get_supported_networks(
+		&self,
+		config: &SolverRuntimeConfig,
+	) -> AdapterResult<Vec<Network>> {
+		debug!(
+			"Across adapter getting supported networks via solver: {}",
+			config.solver_id
+		);
+
+		let client = self.get_client(config)?;
+		let routes_url = format!("{}/available-routes", config.endpoint);
+
+		debug!(
+			"Fetching supported networks from Across adapter at {} (solver: {})",
+			routes_url, config.solver_id
+		);
+
+		// Make the routes request
+		let response = client
+			.get(&routes_url)
+			.send()
+			.await
+			.map_err(AdapterError::HttpError)?;
+
+		if !response.status().is_success() {
+			return Err(AdapterError::InvalidResponse {
+				reason: format!(
+					"Across routes endpoint returned status {}",
+					response.status()
+				),
+			});
+		}
+
+		// Parse the JSON response into Across route models
+		let routes: Vec<AcrossRoute> =
+			response
+				.json()
+				.await
+				.map_err(|e| AdapterError::InvalidResponse {
+					reason: format!("Failed to parse Across routes response: {}", e),
+				})?;
+
+		let routes_count = routes.len();
+		debug!(
+			"Parsed {} routes from Across adapter for networks extraction",
+			routes_count
+		);
+
+		// Extract unique chain IDs from routes
+		let mut unique_chain_ids = HashSet::new();
+		for route in routes {
+			unique_chain_ids.insert(route.origin_chain_id);
+			unique_chain_ids.insert(route.destination_chain_id);
+		}
+
+		// Convert chain IDs to Network models
+		let networks: Vec<Network> = unique_chain_ids
+			.into_iter()
+			.map(|chain_id| Network::new(chain_id, None, None))
+			.collect();
+
+		info!(
+			"Across adapter extracted {} unique networks from {} routes for solver {}",
+			networks.len(),
+			routes_count,
+			config.solver_id
+		);
+
+		Ok(networks)
+	}
+
+	async fn get_supported_assets(
+		&self,
+		config: &SolverRuntimeConfig,
+	) -> AdapterResult<Vec<Asset>> {
+		let client = self.get_client(config)?;
+		let tokens_url = format!("{}/available-routes", config.endpoint);
+
+		debug!(
+			"Fetching supported assets from Across adapter at {} (solver: {})",
+			tokens_url, config.solver_id
+		);
+
+		// Make the tokens request
+		let response = client
+			.get(&tokens_url)
+			.send()
+			.await
+			.map_err(AdapterError::HttpError)?;
+
+		if !response.status().is_success() {
+			return Err(AdapterError::InvalidResponse {
+				reason: format!(
+					"Across tokens endpoint returned status {}",
+					response.status()
+				),
+			});
+		}
+
+		// Parse the JSON response into Across route models
+		let routes: Vec<AcrossRoute> =
+			response
+				.json()
+				.await
+				.map_err(|e| AdapterError::InvalidResponse {
+					reason: format!("Failed to parse Across routes response: {}", e),
+				})?;
+
+		let routes_count = routes.len();
+		debug!("Parsed {} routes from Across adapter", routes_count);
+
+		// Transform Across routes to internal Asset models
+		let mut assets = Vec::new();
+		for route in routes {
+			match route.to_assets() {
+				Ok((origin_asset, destination_asset)) => {
+					assets.push(origin_asset);
+					assets.push(destination_asset);
+				},
+				Err(e) => {
+					warn!("Failed to convert Across route to assets: {}", e);
+					continue;
+				},
+			}
+		}
+
+		// Deduplicate assets by address and chain_id
+		let mut unique_assets = HashSet::new();
+		let mut final_assets = Vec::new();
+
+		for asset in assets {
+			let key = (asset.address.clone(), asset.chain_id);
+			if unique_assets.insert(key) {
+				final_assets.push(asset);
+			}
+		}
+
+		info!(
+			"Across adapter fetched {} unique supported assets from {} routes for solver {}",
+			final_assets.len(),
+			routes_count,
+			config.solver_id
+		);
+
+		Ok(final_assets)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::time::Duration;
+
+	#[test]
+	fn test_across_adapter_construction_patterns() {
+		let config = Adapter::new(
+			"test-across".to_string(),
+			"Test Across".to_string(),
+			"Test Across Adapter".to_string(),
+			"1.0.0".to_string(),
+		);
+
+		// Test optimized constructor (default)
+		let adapter_optimized = AcrossAdapter::new(config.clone()).unwrap();
+		assert!(matches!(
+			adapter_optimized.client_strategy,
+			ClientStrategy::Cached(_)
+		));
+
+		// Test custom cache constructor
+		let custom_cache = ClientCache::with_ttl(Duration::from_secs(60));
+		let adapter_custom = AcrossAdapter::with_cache(config.clone(), custom_cache).unwrap();
+		assert!(matches!(
+			adapter_custom.client_strategy,
+			ClientStrategy::Cached(_)
+		));
+
+		// Test on-demand constructor
+		let adapter_on_demand = AcrossAdapter::without_cache(config.clone()).unwrap();
+		assert!(matches!(
+			adapter_on_demand.client_strategy,
+			ClientStrategy::OnDemand
+		));
+	}
+
+	#[test]
+	fn test_across_adapter_default_config() {
+		let adapter = AcrossAdapter::with_default_config().unwrap();
+		assert_eq!(adapter.id(), "across-v1");
+		assert_eq!(adapter.name(), "Across v1 Adapter");
+		assert!(matches!(adapter.client_strategy, ClientStrategy::Cached(_)));
+	}
+
+	#[test]
+	fn test_across_route_to_assets() {
+		let route = AcrossRoute {
+			origin_chain_id: 1,
+			destination_chain_id: 10,
+			origin_token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
+			destination_token: "0x4200000000000000000000000000000000000006".to_string(),
+			origin_token_symbol: "WETH".to_string(),
+			destination_token_symbol: "WETH".to_string(),
+			is_native: false,
+		};
+
+		let (origin_asset, destination_asset) = route.to_assets().unwrap();
+
+		// Verify origin asset
+		assert_eq!(
+			origin_asset.address,
+			"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+		);
+		assert_eq!(origin_asset.symbol, "WETH");
+		assert_eq!(origin_asset.chain_id, 1);
+		assert_eq!(origin_asset.decimals, 18);
+
+		// Verify destination asset
+		assert_eq!(
+			destination_asset.address,
+			"0x4200000000000000000000000000000000000006"
+		);
+		assert_eq!(destination_asset.symbol, "WETH");
+		assert_eq!(destination_asset.chain_id, 10);
+		assert_eq!(destination_asset.decimals, 18);
+	}
+
+	#[test]
+	fn test_across_route_valid_conversion() {
+		let route = AcrossRoute {
+			origin_chain_id: 1,
+			destination_chain_id: 10,
+			origin_token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
+			destination_token: "0x4200000000000000000000000000000000000006".to_string(),
+			origin_token_symbol: "WETH".to_string(),
+			destination_token_symbol: "WETH".to_string(),
+			is_native: false,
+		};
+
+		// With u64 chain IDs, conversion should always succeed for valid routes
+		assert!(route.to_assets().is_ok());
+		let (origin_asset, destination_asset) = route.to_assets().unwrap();
+
+		// Verify the conversion worked correctly
+		assert_eq!(origin_asset.chain_id, 1);
+		assert_eq!(destination_asset.chain_id, 10);
+		assert_eq!(origin_asset.symbol, "WETH");
+		assert_eq!(destination_asset.symbol, "WETH");
+	}
+
+	#[test]
+	fn test_network_extraction_from_routes() {
+		// Simulate extracting networks from multiple routes
+		let routes = vec![
+			AcrossRoute {
+				origin_chain_id: 1,
+				destination_chain_id: 10,
+				origin_token: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
+				destination_token: "0x4200000000000000000000000000000000000006".to_string(),
+				origin_token_symbol: "WETH".to_string(),
+				destination_token_symbol: "WETH".to_string(),
+				is_native: false,
+			},
+			AcrossRoute {
+				origin_chain_id: 137,
+				destination_chain_id: 1, // Duplicate chain 1
+				origin_token: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174".to_string(),
+				destination_token: "0xA0b86a33E6441E7C81F7C93451777f5F4dE78e86".to_string(),
+				origin_token_symbol: "USDC".to_string(),
+				destination_token_symbol: "USDC".to_string(),
+				is_native: false,
+			},
+		];
+
+		// Extract unique chain IDs
+		let mut unique_chain_ids = HashSet::new();
+		for route in routes {
+			unique_chain_ids.insert(route.origin_chain_id);
+			unique_chain_ids.insert(route.destination_chain_id);
+		}
+
+		// Should have 3 unique chain IDs: 1, 10, 137
+		assert_eq!(unique_chain_ids.len(), 3);
+		assert!(unique_chain_ids.contains(&1)); // Ethereum
+		assert!(unique_chain_ids.contains(&10)); // Optimism
+		assert!(unique_chain_ids.contains(&137)); // Polygon
+
+		// Convert to networks (matching the actual implementation)
+		let networks: Vec<Network> = unique_chain_ids
+			.into_iter()
+			.map(|chain_id| Network::new(chain_id, None, None))
+			.collect();
+
+		assert_eq!(networks.len(), 3);
+
+		// Verify specific networks exist
+		let eth_network = networks.iter().find(|n| n.chain_id == 1).unwrap();
+		assert_eq!(eth_network.name, None);
+
+		let optimism_network = networks.iter().find(|n| n.chain_id == 10).unwrap();
+		assert_eq!(optimism_network.name, None);
+
+		let polygon_network = networks.iter().find(|n| n.chain_id == 137).unwrap();
+		assert_eq!(polygon_network.name, None);
+	}
+
+	#[test]
+	fn test_across_adapter_health_check_url_construction() {
+		let adapter = AcrossAdapter::with_default_config().unwrap();
+		let config = SolverRuntimeConfig {
+			solver_id: "test-across".to_string(),
+			endpoint: "https://api.across.to".to_string(),
+			headers: None,
+		};
+
+		// Test URL construction (this is what the health check method would use)
+		let expected_url = format!("{}/available-routes", config.endpoint);
+		assert_eq!(expected_url, "https://api.across.to/available-routes");
+
+		// Verify adapter configuration
+		assert_eq!(adapter.id(), "across-v1");
+		assert_eq!(adapter.name(), "Across v1 Adapter");
+	}
+
+	#[test]
+	fn test_get_quote_request_construction() {
+		use oif_types::models::InteropAddress;
+		use oif_types::{AvailableInput, RequestedOutput, U256};
+
+		// Test data from user query:
+		// originChainId=11155420&destinationChainId=129399
+		// outputToken=0x17B8Ee96E3bcB3b04b3e8334de4524520C51caB4
+		// inputToken=0x4200000000000000000000000000000000000006
+		// amount=100000000000000
+
+		let origin_chain_id = 11155420u64; // Optimism Sepolia
+		let destination_chain_id = 129399u64; // Custom chain
+		let input_token = "0x4200000000000000000000000000000000000006";
+		let output_token = "0x17B8Ee96E3bcB3b04b3e8334de4524520C51caB4";
+		let amount = "100000000000000"; // 0.0001 ETH (assuming 18 decimals)
+
+		// Create InteropAddress for input token (user and asset)
+		let user_address = InteropAddress::from_chain_and_address(
+			origin_chain_id,
+			"0x742d35Cc6634C0532925a3b8D38BA2297C33A9D7", // Example user address
+		)
+		.expect("Failed to create user InteropAddress");
+
+		let input_asset = InteropAddress::from_chain_and_address(origin_chain_id, input_token)
+			.expect("Failed to create input asset InteropAddress");
+
+		let output_receiver = InteropAddress::from_chain_and_address(
+			destination_chain_id,
+			"0x742d35Cc6634C0532925a3b8D38BA2297C33A9D7", // Same user as receiver
+		)
+		.expect("Failed to create output receiver InteropAddress");
+
+		let output_asset =
+			InteropAddress::from_chain_and_address(destination_chain_id, output_token)
+				.expect("Failed to create output asset InteropAddress");
+
+		// Create U256 from amount string
+		let amount_u256 = U256::new(amount.to_string());
+
+		// Create the GetQuoteRequest
+		let quote_request = GetQuoteRequest {
+			user: user_address.clone(),
+			available_inputs: vec![AvailableInput {
+				user: user_address,
+				asset: input_asset,
+				amount: amount_u256.clone(),
+				lock: None,
+			}],
+			requested_outputs: vec![RequestedOutput {
+				receiver: output_receiver,
+				asset: output_asset,
+				amount: amount_u256, // Same amount for simplicity
+				calldata: None,
+			}],
+			min_valid_until: Some(300), // 5 minutes
+			preference: None,
+		};
+
+		// Serialize to JSON for Postman usage
+		let json_request = serde_json::to_string_pretty(&quote_request)
+			.expect("Failed to serialize GetQuoteRequest to JSON");
+
+		println!("📋 GetQuoteRequest JSON for Postman:");
+		println!("{}", json_request);
+
+		// Verify the request was constructed correctly
+		assert_eq!(quote_request.available_inputs.len(), 1);
+		assert_eq!(quote_request.requested_outputs.len(), 1);
+
+		let input = &quote_request.available_inputs[0];
+		let output = &quote_request.requested_outputs[0];
+
+		// Verify extracted chain IDs and addresses
+		assert_eq!(input.asset.extract_chain_id().unwrap(), origin_chain_id);
+		assert_eq!(
+			input.asset.extract_address().to_lowercase(),
+			input_token.to_lowercase()
+		);
+		assert_eq!(
+			output.asset.extract_chain_id().unwrap(),
+			destination_chain_id
+		);
+		assert_eq!(
+			output.asset.extract_address().to_lowercase(),
+			output_token.to_lowercase()
+		);
+		assert_eq!(input.amount.to_string(), amount);
+		assert_eq!(output.amount.to_string(), amount);
+
+		println!("✅ GetQuoteRequest constructed successfully:");
+		println!(
+			"   Origin Chain: {} -> Token: {}",
+			origin_chain_id, input_token
+		);
+		println!(
+			"   Destination Chain: {} -> Token: {}",
+			destination_chain_id, output_token
+		);
+		println!("   Amount: {} wei", amount);
+	}
+
+	#[test]
+	fn test_across_metadata_enrichment() {
+		// Create a mock Across quote response with rich data
+		let mock_across_response = AcrossQuoteResponse {
+			estimated_fill_time_sec: 120,
+			capital_fee_pct: "78750000000001".to_string(),
+			capital_fee_total: "78750000000001".to_string(),
+			relay_gas_fee_pct: "155024308002".to_string(),
+			relay_gas_fee_total: "155024308002".to_string(),
+			relay_fee_pct: "78905024308003".to_string(),
+			relay_fee_total: "78905024308003".to_string(),
+			lp_fee_pct: "0".to_string(),
+			timestamp: "1754342087".to_string(),
+			is_amount_too_low: false,
+			quote_block: "23070320".to_string(),
+			exclusive_relayer: "0x394311A6Aaa0D8E3411D8b62DE4578D41322d1bD".to_string(),
+			exclusivity_deadline: 1754342267,
+			spoke_pool_address: "0x5c7BCd6E7De5423a257D81B442095A1a6ced35C5".to_string(),
+			destination_spoke_pool_address: "0x6f26Bf09B1C792e3228e5467807a900A503c0281"
+				.to_string(),
+			total_relay_fee: AcrossFeeBand {
+				pct: "78905024308003".to_string(),
+				total: "78905024308003".to_string(),
+			},
+			relayer_capital_fee: AcrossFeeBand {
+				pct: "78750000000001".to_string(),
+				total: "78750000000001".to_string(),
+			},
+			relayer_gas_fee: AcrossFeeBand {
+				pct: "155024308002".to_string(),
+				total: "155024308002".to_string(),
+			},
+			lp_fee: AcrossFeeBand {
+				pct: "0".to_string(),
+				total: "0".to_string(),
+			},
+			limits: AcrossLimits {
+				min_deposit: "134862494200912".to_string(),
+				max_deposit: "1661211802629989209324".to_string(),
+				max_deposit_instant: "231397155893653275446".to_string(),
+				max_deposit_short_delay: "1661211802629989209324".to_string(),
+				recommended_deposit_instant: "231397155893653275446".to_string(),
+			},
+			fill_deadline: "1754353917".to_string(),
+			output_amount: "999921094975691997".to_string(),
+			input_token: AcrossToken {
+				address: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
+				symbol: "ETH".to_string(),
+				decimals: 18,
+				chain_id: 1,
+			},
+			output_token: AcrossToken {
+				address: "0x4200000000000000000000000000000000000006".to_string(),
+				symbol: "ETH".to_string(),
+				decimals: 18,
+				chain_id: 10,
+			},
+			id: "xn8fx-1754342218143-67be35cfbdb6".to_string(),
+		};
+
+		// Create a simple mock request
+		use oif_types::models::InteropAddress;
+		use oif_types::{AvailableInput, RequestedOutput, U256};
+
+		let user_address =
+			InteropAddress::from_chain_and_address(1, "0x742d35Cc6634C0532925a3b8D38BA2297C33A9D7")
+				.expect("Failed to create user address");
+		let input_asset =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.expect("Failed to create input asset");
+		let output_asset = InteropAddress::from_chain_and_address(
+			10,
+			"0x4200000000000000000000000000000000000006",
+		)
+		.expect("Failed to create output asset");
+
+		let mock_request = GetQuoteRequest {
+			user: user_address.clone(),
+			available_inputs: vec![AvailableInput {
+				user: user_address.clone(),
+				asset: input_asset,
+				amount: U256::new("1000000000000000000".to_string()),
+				lock: None,
+			}],
+			requested_outputs: vec![RequestedOutput {
+				receiver: user_address,
+				asset: output_asset,
+				amount: U256::new("999000000000000000".to_string()),
+				calldata: None,
+			}],
+			min_valid_until: Some(600),
+			preference: None,
+		};
+
+		let mock_config = SolverRuntimeConfig {
+			solver_id: "test-across".to_string(),
+			endpoint: "https://api.across.to".to_string(),
+			headers: None,
+		};
+
+		// Create the adapter and convert the response
+		let adapter = AcrossAdapter::with_default_config().expect("Failed to create adapter");
+
+		let adapter_quote = adapter
+			.convert_across_quote_to_adapter_quote(
+				mock_across_response,
+				&mock_request,
+				&mock_config,
+			)
+			.expect("Failed to convert Across response");
+
+		// Serialize the enriched response to JSON
+		let json_response = serde_json::to_string_pretty(&adapter_quote)
+			.expect("Failed to serialize AdapterQuote to JSON");
+
+		println!("🎯 Enhanced AdapterQuote with Across Metadata:");
+		println!("{}", json_response);
+
+		// Verify metadata is present
+		assert!(adapter_quote.metadata.is_some());
+
+		let metadata = adapter_quote.metadata.unwrap();
+		assert!(metadata.get("across").is_some());
+
+		let across_data = &metadata["across"];
+		// Verify key Across fields are present (flat structure)
+		assert!(across_data.get("capitalFeePct").is_some());
+		assert!(across_data.get("spokePoolAddress").is_some());
+		assert!(across_data.get("limits").is_some());
+		assert!(across_data.get("inputToken").is_some());
+		assert!(across_data.get("outputToken").is_some());
+		assert!(across_data.get("estimatedFillTimeSec").is_some());
+		assert!(across_data.get("id").is_some());
+
+		println!("✅ All Across metadata fields are present and accessible!");
+		println!("✅ Simplified approach: Complete Across response serialized as-is!");
+	}
+
+	#[tokio::test]
+	async fn test_get_quotes_with_real_data() {
+		use oif_types::models::InteropAddress;
+		use oif_types::{AvailableInput, RequestedOutput, U256};
+
+		// Same test data as above but with async quote request
+		let origin_chain_id = 11155420u64; // Optimism Sepolia
+		let destination_chain_id = 129399u64; // Custom chain
+		let input_token = "0x4200000000000000000000000000000000000006";
+		let output_token = "0x17B8Ee96E3bcB3b04b3e8334de4524520C51caB4";
+		let amount = "100000000000000";
+
+		// Create the adapter
+		let adapter = AcrossAdapter::with_default_config().expect("Failed to create adapter");
+
+		// Create runtime config
+		let runtime_config = SolverRuntimeConfig {
+			solver_id: "test-across".to_string(),
+			endpoint: "https://api.across.to".to_string(),
+			headers: None,
+		};
+
+		// Create InteropAddresses
+		let user_address = InteropAddress::from_chain_and_address(
+			origin_chain_id,
+			"0x742d35Cc6634C0532925a3b8D38BA2297C33A9D7",
+		)
+		.expect("Failed to create user InteropAddress");
+
+		let input_asset = InteropAddress::from_chain_and_address(origin_chain_id, input_token)
+			.expect("Failed to create input asset InteropAddress");
+
+		let output_receiver = InteropAddress::from_chain_and_address(
+			destination_chain_id,
+			"0x742d35Cc6634C0532925a3b8D38BA2297C33A9D7",
+		)
+		.expect("Failed to create output receiver InteropAddress");
+
+		let output_asset =
+			InteropAddress::from_chain_and_address(destination_chain_id, output_token)
+				.expect("Failed to create output asset InteropAddress");
+
+		let amount_u256 = U256::new(amount.to_string());
+
+		// Create the GetQuoteRequest
+		let quote_request = GetQuoteRequest {
+			user: user_address.clone(),
+			available_inputs: vec![AvailableInput {
+				user: user_address,
+				asset: input_asset,
+				amount: amount_u256.clone(),
+				lock: None,
+			}],
+			requested_outputs: vec![RequestedOutput {
+				receiver: output_receiver,
+				asset: output_asset,
+				amount: amount_u256,
+				calldata: None,
+			}],
+			min_valid_until: Some(300),
+			preference: None,
+		};
+
+		// Test the actual get_quotes method
+		// Note: This will make a real HTTP request to Across API, so it might fail in CI
+		println!("🚀 Testing get_quotes with real data...");
+		println!(
+			"   Request: {}:{} -> {}:{}",
+			origin_chain_id, input_token, destination_chain_id, output_token
+		);
+		println!("   Amount: {} wei", amount);
+
+		match adapter.get_quotes(&quote_request, &runtime_config).await {
+			Ok(response) => {
+				println!("✅ Quote request successful!");
+				println!("   Received {} quotes", response.quotes.len());
+
+				if !response.quotes.is_empty() {
+					let quote = &response.quotes[0];
+					println!("   Quote ID: {}", quote.quote_id);
+					println!("   Provider: {}", quote.provider);
+					if let Some(eta) = quote.eta {
+						println!("   ETA: {} seconds", eta);
+					}
+				}
+
+				// Verify we got at least one quote
+				assert!(
+					!response.quotes.is_empty(),
+					"Should receive at least one quote"
+				);
+			},
+			Err(e) => {
+				println!(
+					"⚠️  Quote request failed (this might be expected in CI): {}",
+					e
+				);
+				// In a real test environment, we might want to mock the HTTP response
+				// For now, we just print the error and don't fail the test
+				// This allows the test to pass in CI environments without network access
+			},
+		}
+	}
+}

--- a/crates/adapters/src/across_adapter.rs
+++ b/crates/adapters/src/across_adapter.rs
@@ -8,7 +8,7 @@ use oif_types::adapters::AdapterQuote;
 use oif_types::{
 	Adapter, Asset, AssetRoute, GetQuoteRequest, GetQuoteResponse, SolverRuntimeConfig,
 };
-use oif_types::{AdapterError, AdapterResult, SolverAdapter};
+use oif_types::{AdapterError, AdapterResult, SolverAdapter, SupportedAssetsData};
 use reqwest::{
 	header::{HeaderMap, HeaderValue},
 	Client,
@@ -505,12 +505,12 @@ impl SolverAdapter for AcrossAdapter {
 		}
 	}
 
-	async fn get_supported_routes(
+	async fn get_supported_assets(
 		&self,
 		config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<AssetRoute>> {
+	) -> AdapterResult<SupportedAssetsData> {
 		debug!(
-			"Across adapter getting supported routes via solver: {}",
+			"Across adapter getting supported routes for solver: {}",
 			config.solver_id
 		);
 
@@ -568,13 +568,13 @@ impl SolverAdapter for AcrossAdapter {
 		}
 
 		info!(
-			"Across adapter converted {} Across routes to {} asset routes for solver {}",
+			"Across adapter converted {} Across routes to {} asset routes for solver {} (using routes mode)",
 			routes_count,
 			asset_routes.len(),
 			config.solver_id
 		);
 
-		Ok(asset_routes)
+		Ok(SupportedAssetsData::Routes(asset_routes))
 	}
 }
 

--- a/crates/adapters/src/across_adapter.rs
+++ b/crates/adapters/src/across_adapter.rs
@@ -722,13 +722,13 @@ mod tests {
 		let adapter = AcrossAdapter::with_default_config().unwrap();
 		let config = SolverRuntimeConfig {
 			solver_id: "test-across".to_string(),
-			endpoint: "https://api.across.to".to_string(),
+			endpoint: "https://app.across.to".to_string(),
 			headers: None,
 		};
 
 		// Test URL construction (this is what the health check method would use)
 		let expected_url = format!("{}/available-routes", config.endpoint);
-		assert_eq!(expected_url, "https://api.across.to/available-routes");
+		assert_eq!(expected_url, "https://app.across.to/available-routes");
 
 		// Verify adapter configuration
 		assert_eq!(adapter.id(), "across-v1");

--- a/crates/adapters/src/across_adapter.rs
+++ b/crates/adapters/src/across_adapter.rs
@@ -1036,7 +1036,6 @@ mod tests {
 		assert!(across_data.get("id").is_some());
 
 		println!("✅ All Across metadata fields are present and accessible!");
-		println!("✅ Simplified approach: Complete Across response serialized as-is!");
 	}
 
 	#[tokio::test]

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust,no_run
 //! use oif_adapters::{ClientCache, SolverAdapter, AdapterResult};
-//! use oif_types::{Adapter, SolverRuntimeConfig, GetQuoteRequest, GetQuoteResponse, Asset, Network, AssetRoute};
+//! use oif_types::{Adapter, SolverRuntimeConfig, GetQuoteRequest, GetQuoteResponse, SupportedAssetsData};
 //! use oif_types::adapters::{models::{SubmitOrderRequest, SubmitOrderResponse}, GetOrderResponse};
 //! use async_trait::async_trait;
 //! use std::sync::Arc;
@@ -52,7 +52,7 @@
 //!     }
 //!     
 //!     async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> { todo!() }
-//!     async fn get_supported_routes(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<AssetRoute>> { todo!() }
+//!     async fn get_supported_assets(&self, _config: &SolverRuntimeConfig) -> AdapterResult<SupportedAssetsData> { todo!() }
 //! }
 //! ```
 //!

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust,no_run
 //! use oif_adapters::{ClientCache, SolverAdapter, AdapterResult};
-//! use oif_types::{Adapter, SolverRuntimeConfig, GetQuoteRequest, GetQuoteResponse, Asset, Network};
+//! use oif_types::{Adapter, SolverRuntimeConfig, GetQuoteRequest, GetQuoteResponse, Asset, Network, AssetRoute};
 //! use oif_types::adapters::{models::{SubmitOrderRequest, SubmitOrderResponse}, GetOrderResponse};
 //! use async_trait::async_trait;
 //! use std::sync::Arc;
@@ -53,7 +53,7 @@
 //!     
 //!     async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> { todo!() }
 //!     async fn get_supported_networks(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<Network>> { todo!() }
-//!     async fn get_supported_assets(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<Asset>> { todo!() }
+//!     async fn get_supported_routes(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<AssetRoute>> { todo!() }
 //! }
 //! ```
 //!

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -52,7 +52,6 @@
 //!     }
 //!     
 //!     async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> { todo!() }
-//!     async fn get_supported_networks(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<Network>> { todo!() }
 //!     async fn get_supported_routes(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<AssetRoute>> { todo!() }
 //! }
 //! ```

--- a/crates/adapters/src/lib.rs
+++ b/crates/adapters/src/lib.rs
@@ -43,19 +43,15 @@
 //!
 //! #[async_trait]
 //! impl SolverAdapter for MyCustomAdapter {
-//!     fn adapter_id(&self) -> &str { &self.config.adapter_id }
-//!     fn adapter_name(&self) -> &str { &self.config.name }
 //!     fn adapter_info(&self) -> &Adapter { &self.config }
-//!     
+//!
 //!     async fn get_quotes(&self, _request: &GetQuoteRequest, config: &SolverRuntimeConfig) -> AdapterResult<GetQuoteResponse> {
 //!         let _client = self.get_client(config)?; // ← Optimized cached client
 //!         // Your implementation here
 //!         todo!()
 //!     }
 //!     
-//!     async fn submit_order(&self, _order: &SubmitOrderRequest, _config: &SolverRuntimeConfig) -> AdapterResult<SubmitOrderResponse> { todo!() }
 //!     async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> { todo!() }
-//!     async fn get_order_details(&self, _order_id: &str, _config: &SolverRuntimeConfig) -> AdapterResult<GetOrderResponse> { todo!() }
 //!     async fn get_supported_networks(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<Network>> { todo!() }
 //!     async fn get_supported_assets(&self, _config: &SolverRuntimeConfig) -> AdapterResult<Vec<Asset>> { todo!() }
 //! }
@@ -99,10 +95,12 @@
 
 use std::sync::Arc;
 
+pub mod across_adapter;
 pub mod client_cache;
 pub mod lifi_adapter;
 pub mod oif_adapter;
 
+pub use across_adapter::AcrossAdapter;
 pub use lifi_adapter::LifiAdapter;
 pub use oif_adapter::OifAdapter;
 pub use oif_types::{AdapterError, AdapterResult, SolverAdapter};
@@ -142,6 +140,11 @@ impl AdapterRegistry {
 			let _ = registry.register(Box::new(lifi_adapter));
 		}
 
+		// Add default Across adapter
+		if let Ok(across_adapter) = AcrossAdapter::with_default_config() {
+			let _ = registry.register(Box::new(across_adapter));
+		}
+
 		registry
 	}
 
@@ -152,7 +155,7 @@ impl AdapterRegistry {
 
 	/// Register an adapter (uses the adapter's own ID)
 	pub fn register(&mut self, adapter: Box<dyn SolverAdapter>) -> Result<(), String> {
-		let adapter_id = adapter.adapter_id().to_string();
+		let adapter_id = adapter.id().to_string();
 
 		// Check for duplicate IDs
 		if self.adapters.contains_key(&adapter_id) {

--- a/crates/adapters/src/lifi_adapter.rs
+++ b/crates/adapters/src/lifi_adapter.rs
@@ -3,7 +3,9 @@
 //! This adapter uses an optimized client cache for connection pooling and keep-alive.
 
 use async_trait::async_trait;
-use oif_types::{Adapter, Asset, GetQuoteRequest, GetQuoteResponse, Network, SolverRuntimeConfig};
+use oif_types::{
+	Adapter, AssetRoute, GetQuoteRequest, GetQuoteResponse, Network, SolverRuntimeConfig,
+};
 use oif_types::{AdapterError, AdapterResult, SolverAdapter};
 use reqwest::{
 	header::{HeaderMap, HeaderValue},
@@ -156,16 +158,17 @@ impl SolverAdapter for LifiAdapter {
 		unimplemented!()
 	}
 
-	async fn get_supported_assets(
+	async fn get_supported_routes(
 		&self,
 		config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Asset>> {
+	) -> AdapterResult<Vec<AssetRoute>> {
 		debug!(
-			"LiFi adapter getting supported assets via solver: {}",
+			"LiFi adapter getting supported routes via solver: {}",
 			config.solver_id
 		);
 
-		unimplemented!()
+		// TODO: Implement LiFi route fetching
+		Ok(Vec::new())
 	}
 }
 

--- a/crates/adapters/src/lifi_adapter.rs
+++ b/crates/adapters/src/lifi_adapter.rs
@@ -3,9 +3,7 @@
 //! This adapter uses an optimized client cache for connection pooling and keep-alive.
 
 use async_trait::async_trait;
-use oif_types::{
-	Adapter, AssetRoute, GetQuoteRequest, GetQuoteResponse, Network, SolverRuntimeConfig,
-};
+use oif_types::{Adapter, AssetRoute, GetQuoteRequest, GetQuoteResponse, SolverRuntimeConfig};
 use oif_types::{AdapterError, AdapterResult, SolverAdapter};
 use reqwest::{
 	header::{HeaderMap, HeaderValue},
@@ -142,18 +140,6 @@ impl SolverAdapter for LifiAdapter {
 
 	async fn health_check(&self, config: &SolverRuntimeConfig) -> AdapterResult<bool> {
 		debug!("LiFi adapter health check for solver: {}", config.solver_id);
-
-		unimplemented!()
-	}
-
-	async fn get_supported_networks(
-		&self,
-		config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Network>> {
-		debug!(
-			"LiFi adapter getting supported networks via solver: {}",
-			config.solver_id
-		);
 
 		unimplemented!()
 	}

--- a/crates/adapters/src/lifi_adapter.rs
+++ b/crates/adapters/src/lifi_adapter.rs
@@ -3,10 +3,6 @@
 //! This adapter uses an optimized client cache for connection pooling and keep-alive.
 
 use async_trait::async_trait;
-use oif_types::adapters::{
-	models::{SubmitOrderRequest, SubmitOrderResponse},
-	GetOrderResponse,
-};
 use oif_types::{Adapter, Asset, GetQuoteRequest, GetQuoteResponse, Network, SolverRuntimeConfig};
 use oif_types::{AdapterError, AdapterResult, SolverAdapter};
 use reqwest::{
@@ -123,14 +119,6 @@ impl LifiAdapter {
 
 #[async_trait]
 impl SolverAdapter for LifiAdapter {
-	fn adapter_id(&self) -> &str {
-		&self.config.adapter_id
-	}
-
-	fn adapter_name(&self) -> &str {
-		&self.config.name
-	}
-
 	fn adapter_info(&self) -> &Adapter {
 		&self.config
 	}
@@ -150,33 +138,8 @@ impl SolverAdapter for LifiAdapter {
 		unimplemented!()
 	}
 
-	async fn submit_order(
-		&self,
-		order: &SubmitOrderRequest,
-		config: &SolverRuntimeConfig,
-	) -> AdapterResult<SubmitOrderResponse> {
-		debug!(
-			"LiFi adapter submitting order: {:?} via solver: {}",
-			order, config.solver_id
-		);
-		unimplemented!()
-	}
-
 	async fn health_check(&self, config: &SolverRuntimeConfig) -> AdapterResult<bool> {
 		debug!("LiFi adapter health check for solver: {}", config.solver_id);
-
-		unimplemented!()
-	}
-
-	async fn get_order_details(
-		&self,
-		order_id: &str,
-		config: &SolverRuntimeConfig,
-	) -> AdapterResult<GetOrderResponse> {
-		debug!(
-			"LiFi adapter getting order details for: {} via solver: {}",
-			order_id, config.solver_id
-		);
 
 		unimplemented!()
 	}
@@ -246,8 +209,8 @@ mod tests {
 	#[test]
 	fn test_lifi_adapter_default_config() {
 		let adapter = LifiAdapter::with_default_config().unwrap();
-		assert_eq!(adapter.adapter_id(), "lifi-v1");
-		assert_eq!(adapter.adapter_name(), "LiFi v1 Adapter");
+		assert_eq!(adapter.id(), "lifi-v1");
+		assert_eq!(adapter.name(), "LiFi v1 Adapter");
 		assert!(matches!(adapter.client_strategy, ClientStrategy::Cached(_)));
 	}
 }

--- a/crates/adapters/src/lifi_adapter.rs
+++ b/crates/adapters/src/lifi_adapter.rs
@@ -3,8 +3,8 @@
 //! This adapter uses an optimized client cache for connection pooling and keep-alive.
 
 use async_trait::async_trait;
-use oif_types::{Adapter, AssetRoute, GetQuoteRequest, GetQuoteResponse, SolverRuntimeConfig};
-use oif_types::{AdapterError, AdapterResult, SolverAdapter};
+use oif_types::{Adapter, GetQuoteRequest, GetQuoteResponse, SolverRuntimeConfig};
+use oif_types::{AdapterError, AdapterResult, SolverAdapter, SupportedAssetsData};
 use reqwest::{
 	header::{HeaderMap, HeaderValue},
 	Client,
@@ -144,17 +144,18 @@ impl SolverAdapter for LifiAdapter {
 		unimplemented!()
 	}
 
-	async fn get_supported_routes(
+	async fn get_supported_assets(
 		&self,
 		config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<AssetRoute>> {
+	) -> AdapterResult<SupportedAssetsData> {
 		debug!(
-			"LiFi adapter getting supported routes via solver: {}",
+			"LiFi adapter getting supported assets for solver: {}",
 			config.solver_id
 		);
 
-		// TODO: Implement LiFi route fetching
-		Ok(Vec::new())
+		// TODO: Implement LiFi asset/route fetching
+		// For now, return empty assets mode
+		Ok(SupportedAssetsData::Assets(Vec::new()))
 	}
 }
 

--- a/crates/adapters/src/oif_adapter.rs
+++ b/crates/adapters/src/oif_adapter.rs
@@ -144,14 +144,6 @@ impl OifAdapter {
 
 #[async_trait]
 impl SolverAdapter for OifAdapter {
-	fn adapter_id(&self) -> &str {
-		&self.config.adapter_id
-	}
-
-	fn adapter_name(&self) -> &str {
-		&self.config.name
-	}
-
 	fn adapter_info(&self) -> &Adapter {
 		&self.config
 	}
@@ -500,8 +492,8 @@ mod tests {
 	#[test]
 	fn test_oif_adapter_default_config() {
 		let adapter = OifAdapter::with_default_config().unwrap();
-		assert_eq!(adapter.adapter_id(), "oif-v1");
-		assert_eq!(adapter.adapter_name(), "OIF v1 Adapter");
+		assert_eq!(adapter.id(), "oif-v1");
+		assert_eq!(adapter.name(), "OIF v1 Adapter");
 		assert!(matches!(adapter.client_strategy, ClientStrategy::Cached(_)));
 	}
 

--- a/crates/adapters/src/oif_adapter.rs
+++ b/crates/adapters/src/oif_adapter.rs
@@ -235,19 +235,11 @@ impl OifAdapter {
 						),
 					) {
 						(Ok(origin_addr), Ok(dest_addr)) => {
-							let metadata = serde_json::json!({
-								"source": "generated-from-assets",
-								"originChainId": origin.chain_id,
-								"destinationChainId": destination.chain_id,
-								"generatedAt": chrono::Utc::now().timestamp()
-							});
-
-							routes.push(AssetRoute::with_symbols_and_metadata(
+							routes.push(AssetRoute::with_symbols(
 								origin_addr,
 								origin.symbol.clone(),
 								dest_addr,
 								destination.symbol.clone(),
-								metadata,
 							));
 						},
 						(Err(e), _) | (_, Err(e)) => {
@@ -728,12 +720,6 @@ mod tests {
 		for route in &routes {
 			assert!(route.is_cross_chain());
 			assert!(!route.is_same_chain());
-
-			// Verify metadata
-			assert!(route.metadata.is_some());
-			let metadata = route.metadata.as_ref().unwrap();
-			assert_eq!(metadata["source"], "generated-from-assets");
-			assert!(metadata.get("generatedAt").is_some());
 		}
 
 		// Verify specific routes exist

--- a/crates/config/src/settings.rs
+++ b/crates/config/src/settings.rs
@@ -65,7 +65,7 @@ impl From<SolverConfig> for DomainSolverConfig {
 			version: None,
 			supported_routes: settings_config
 				.supported_routes
-				.map(|routes| routes.into_iter().map(|r| r.into()).collect()),
+				.map(|routes| routes.into_iter().collect()),
 			config: None,
 		}
 	}

--- a/crates/config/src/settings.rs
+++ b/crates/config/src/settings.rs
@@ -6,6 +6,7 @@ use oif_types::constants::limits::{
 	DEFAULT_ORDER_RETENTION_DAYS, DEFAULT_RETRY_DELAY_MS,
 };
 use oif_types::constants::DEFAULT_SOLVER_TIMEOUT_MS;
+use oif_types::solvers::RouteConfig;
 use oif_types::SecretString;
 use oif_types::SolverConfig as DomainSolverConfig;
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,7 @@ pub struct SolverConfig {
 	pub name: Option<String>,
 	pub description: Option<String>,
 	// Optional domain metadata for discoverability
-	pub supported_assets: Option<Vec<AssetConfig>>,
+	pub supported_routes: Option<Vec<RouteConfig>>,
 }
 
 /// Convert from settings SolverConfig to domain SolverConfig
@@ -62,14 +63,9 @@ impl From<SolverConfig> for DomainSolverConfig {
 			name: settings_config.name,
 			description: settings_config.description,
 			version: None,
-			supported_assets: settings_config.supported_assets.map(|assets| {
-				assets
-					.into_iter()
-					.map(|a| {
-						oif_types::Asset::new(a.address, a.symbol, a.name, a.decimals, a.chain_id)
-					})
-					.collect()
-			}),
+			supported_routes: settings_config
+				.supported_routes
+				.map(|routes| routes.into_iter().map(|r| r.into()).collect()),
 			config: None,
 		}
 	}
@@ -81,16 +77,6 @@ pub struct NetworkConfig {
 	pub chain_id: u64,
 	pub name: String,
 	pub is_testnet: bool,
-}
-
-/// Minimal asset shape for config to avoid cross-crate cycle
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct AssetConfig {
-	pub address: String,
-	pub symbol: String,
-	pub name: String,
-	pub decimals: u8,
-	pub chain_id: u64,
 }
 
 /// Aggregation behavior configuration

--- a/crates/service/src/aggregator.rs
+++ b/crates/service/src/aggregator.rs
@@ -1181,24 +1181,6 @@ mod tests {
 			Ok(!self.should_fail)
 		}
 
-		async fn get_supported_networks(
-			&self,
-			_config: &oif_types::SolverRuntimeConfig,
-		) -> oif_types::AdapterResult<Vec<oif_types::models::Network>> {
-			if self.should_fail {
-				return Err(oif_types::AdapterError::from(
-					oif_types::adapters::AdapterValidationError::InvalidConfiguration {
-						reason: format!("Mock adapter {} configured to fail", self.id),
-					},
-				));
-			}
-			Ok(vec![oif_types::models::Network::new(
-				1,
-				Some("Ethereum Mainnet".to_string()),
-				Some(false),
-			)])
-		}
-
 		async fn get_supported_routes(
 			&self,
 			_config: &oif_types::SolverRuntimeConfig,

--- a/crates/service/src/aggregator.rs
+++ b/crates/service/src/aggregator.rs
@@ -1199,10 +1199,10 @@ mod tests {
 			Ok(!self.should_fail)
 		}
 
-		async fn get_supported_routes(
+		async fn get_supported_assets(
 			&self,
 			_config: &oif_types::SolverRuntimeConfig,
-		) -> oif_types::AdapterResult<Vec<oif_types::AssetRoute>> {
+		) -> oif_types::AdapterResult<oif_types::adapters::SupportedAssetsData> {
 			if self.should_fail {
 				return Err(oif_types::AdapterError::from(
 					oif_types::adapters::AdapterValidationError::InvalidConfiguration {
@@ -1210,7 +1210,7 @@ mod tests {
 					},
 				));
 			}
-			Ok(vec![])
+			Ok(oif_types::adapters::SupportedAssetsData::Routes(vec![]))
 		}
 	}
 

--- a/crates/service/src/aggregator.rs
+++ b/crates/service/src/aggregator.rs
@@ -925,8 +925,8 @@ mod tests {
 	use super::*;
 	use oif_adapters::AdapterRegistry;
 	use oif_types::{
-		AvailableInput, InteropAddress, QuoteDetails, QuoteRequest, RequestedOutput, SecretString,
-		SolverAdapter, U256,
+		AssetRoute, AvailableInput, InteropAddress, QuoteDetails, QuoteRequest, RequestedOutput,
+		SecretString, SolverAdapter, U256,
 	};
 
 	/// Simple mock adapter for testing success scenarios
@@ -1199,10 +1199,10 @@ mod tests {
 			)])
 		}
 
-		async fn get_supported_assets(
+		async fn get_supported_routes(
 			&self,
 			_config: &oif_types::SolverRuntimeConfig,
-		) -> oif_types::AdapterResult<Vec<oif_types::models::Asset>> {
+		) -> oif_types::AdapterResult<Vec<oif_types::AssetRoute>> {
 			if self.should_fail {
 				return Err(oif_types::AdapterError::from(
 					oif_types::adapters::AdapterValidationError::InvalidConfiguration {
@@ -1256,77 +1256,107 @@ mod tests {
 		let solvers = vec![
 			// Fast solver that will succeed
 			{
-				let mut solver = Solver::new(
+				let solver = Solver::new(
 					"fast-solver".to_string(),
 					"mock-fast-adapter".to_string(),
 					"http://localhost:8001".to_string(),
-				);
-				solver.metadata.supported_assets = vec![
-					oif_types::models::Asset::new(
-						"0x0000000000000000000000000000000000000000".to_string(),
+				)
+				.with_routes(vec![
+					AssetRoute::with_symbols(
+						InteropAddress::from_text(
+							"eip155:1:0x0000000000000000000000000000000000000000",
+						)
+						.unwrap(), // ETH on Ethereum
 						"ETH".to_string(),
-						"Ethereum".to_string(),
-						18,
-						1,
-					),
-					oif_types::models::Asset::new(
-						"0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0".to_string(),
+						InteropAddress::from_text(
+							"eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+						)
+						.unwrap(), // USDC on Optimism
 						"USDC".to_string(),
-						"USD Coin".to_string(),
-						6,
-						1,
 					),
-				];
+					AssetRoute::with_symbols(
+						InteropAddress::from_text(
+							"eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+						)
+						.unwrap(), // USDC on Optimism
+						"USDC".to_string(),
+						InteropAddress::from_text(
+							"eip155:1:0x0000000000000000000000000000000000000000",
+						)
+						.unwrap(), // ETH on Ethereum
+						"ETH".to_string(),
+					),
+				]);
 				solver
 			},
 			// Slow solver that will timeout
 			{
-				let mut solver = Solver::new(
+				let solver = Solver::new(
 					"slow-solver".to_string(),
 					"mock-slow-adapter".to_string(),
 					"http://localhost:8002".to_string(),
-				);
-				solver.metadata.supported_assets = vec![
-					oif_types::models::Asset::new(
-						"0x0000000000000000000000000000000000000000".to_string(),
+				)
+				.with_routes(vec![
+					AssetRoute::with_symbols(
+						InteropAddress::from_text(
+							"eip155:1:0x0000000000000000000000000000000000000000",
+						)
+						.unwrap(), // ETH on Ethereum
 						"ETH".to_string(),
-						"Ethereum".to_string(),
-						18,
-						1,
-					),
-					oif_types::models::Asset::new(
-						"0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0".to_string(),
+						InteropAddress::from_text(
+							"eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+						)
+						.unwrap(), // USDC on Optimism
 						"USDC".to_string(),
-						"USD Coin".to_string(),
-						6,
-						1,
 					),
-				];
+					AssetRoute::with_symbols(
+						InteropAddress::from_text(
+							"eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+						)
+						.unwrap(), // USDC on Optimism
+						"USDC".to_string(),
+						InteropAddress::from_text(
+							"eip155:1:0x0000000000000000000000000000000000000000",
+						)
+						.unwrap(), // ETH on Ethereum
+						"ETH".to_string(),
+					),
+				]);
 				solver
 			},
 			// Another fast solver for comparison
 			{
-				let mut solver = Solver::new(
+				let solver = Solver::new(
 					"fast-solver2".to_string(),
 					"mock-demo-v1".to_string(),
 					"http://localhost:8003".to_string(),
-				);
-				solver.metadata.supported_assets = vec![
-					oif_types::models::Asset::new(
-						"0x0000000000000000000000000000000000000000".to_string(),
+				)
+				.with_routes(vec![
+					AssetRoute::with_symbols(
+						InteropAddress::from_text(
+							"eip155:1:0x0000000000000000000000000000000000000000",
+						)
+						.unwrap(), // ETH on Ethereum
 						"ETH".to_string(),
-						"Ethereum".to_string(),
-						18,
-						1,
-					),
-					oif_types::models::Asset::new(
-						"0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0".to_string(),
+						InteropAddress::from_text(
+							"eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+						)
+						.unwrap(), // USDC on Optimism
 						"USDC".to_string(),
-						"USD Coin".to_string(),
-						6,
-						1,
 					),
-				];
+					AssetRoute::with_symbols(
+						InteropAddress::from_text(
+							"eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+						)
+						.unwrap(), // USDC on Optimism
+						"USDC".to_string(),
+						InteropAddress::from_text(
+							"eip155:1:0x0000000000000000000000000000000000000000",
+						)
+						.unwrap(), // ETH on Ethereum
+						"ETH".to_string(),
+					),
+				]);
 				solver
 			},
 		];
@@ -1357,29 +1387,26 @@ mod tests {
 		let mut solvers = Vec::new();
 		for i in 1..=solver_count {
 			// Create solver with proper network and asset support for filtering
-			let mut solver = Solver::new(
+			let solver = Solver::new(
 				format!("demo-solver{}", i),
 				"mock-demo-v1".to_string(), // Use actual mock adapter ID
 				format!("http://localhost:800{}", i),
-			);
-
-			// Add network and asset support to prevent filtering issues
-			solver.metadata.supported_assets = vec![
-				oif_types::models::Asset::new(
-					"0x0000000000000000000000000000000000000000".to_string(),
+			)
+			// Add cross-chain routes support
+			.with_routes(vec![
+				AssetRoute::with_symbols(
+					InteropAddress::from_text("eip155:1:0x0000000000000000000000000000000000000000").unwrap(), // ETH on Ethereum
 					"ETH".to_string(),
-					"Ethereum".to_string(),
-					18,
-					1,
-				),
-				oif_types::models::Asset::new(
-					"0xa0b86a33e6417a77c9a0c65f8e69b8b6e2b0c4a0".to_string(),
+					InteropAddress::from_text("eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607").unwrap(), // USDC on Optimism
 					"USDC".to_string(),
-					"USD Coin".to_string(),
-					6,
-					1,
 				),
-			];
+				AssetRoute::with_symbols(
+					InteropAddress::from_text("eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607").unwrap(), // USDC on Optimism
+					"USDC".to_string(),
+					InteropAddress::from_text("eip155:1:0x0000000000000000000000000000000000000000").unwrap(), // ETH on Ethereum
+					"ETH".to_string(),
+				),
+			]);
 
 			solvers.push(solver);
 		}
@@ -1446,21 +1473,24 @@ mod tests {
 	fn create_valid_quote_request() -> QuoteRequest {
 		let user = InteropAddress::from_text("eip155:1:0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 			.unwrap();
-		let asset =
-			InteropAddress::from_text("eip155:1:0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0")
+		let input_asset =
+			InteropAddress::from_text("eip155:1:0x0000000000000000000000000000000000000000") // ETH on Ethereum
+				.unwrap();
+		let output_asset =
+			InteropAddress::from_text("eip155:10:0x7F5c764cBc14f9669B88837ca1490cCa17c31607") // USDC on Optimism
 				.unwrap();
 
 		QuoteRequest {
 			user: user.clone(),
 			available_inputs: vec![AvailableInput {
 				user: user.clone(),
-				asset: asset.clone(),
+				asset: input_asset,
 				amount: U256::from(1000u64),
 				lock: None,
 			}],
 			requested_outputs: vec![RequestedOutput {
 				receiver: user,
-				asset,
+				asset: output_asset,
 				amount: U256::from(500u64),
 				calldata: None,
 			}],

--- a/crates/service/src/jobs/handlers/solver_fetch_assets.rs
+++ b/crates/service/src/jobs/handlers/solver_fetch_assets.rs
@@ -23,11 +23,11 @@ impl SolverFetchAssetsHandler {
 #[async_trait]
 impl GenericJobHandler<SolverFetchAssetsParams> for SolverFetchAssetsHandler {
 	async fn handle(&self, params: SolverFetchAssetsParams) -> JobResult<()> {
-		debug!("Starting asset fetch for solver: {}", params.solver_id);
+		debug!("Starting route fetch for solver: {}", params.solver_id);
 
 		// Delegate to the solver service which contains the business logic
 		self.solver_service
-			.fetch_and_update_assets(&params.solver_id)
+			.fetch_and_update_routes(&params.solver_id)
 			.await
 			.map_err(|e| match e {
 				crate::solver_repository::SolverServiceError::Storage(msg) => {
@@ -38,7 +38,7 @@ impl GenericJobHandler<SolverFetchAssetsParams> for SolverFetchAssetsHandler {
 				},
 			})?;
 
-		debug!("Asset fetch completed for solver: {}", params.solver_id);
+		debug!("Route fetch completed for solver: {}", params.solver_id);
 		Ok(())
 	}
 }
@@ -64,7 +64,7 @@ mod tests {
 				name: Some("Test Solver".to_string()),
 				description: Some("Test solver for unit testing".to_string()),
 				version: None,
-				supported_assets: vec![],
+				supported_routes: Vec::new(),
 				assets_source: AssetSource::AutoDiscovered, // Test solver for auto-discovery
 				headers: None,
 				config: HashMap::new(),

--- a/crates/service/src/jobs/handlers/solver_fetch_assets.rs
+++ b/crates/service/src/jobs/handlers/solver_fetch_assets.rs
@@ -27,7 +27,7 @@ impl GenericJobHandler<SolverFetchAssetsParams> for SolverFetchAssetsHandler {
 
 		// Delegate to the solver service which contains the business logic
 		self.solver_service
-			.fetch_and_update_routes(&params.solver_id)
+			.fetch_and_update_assets(&params.solver_id)
 			.await
 			.map_err(|e| match e {
 				crate::solver_repository::SolverServiceError::Storage(msg) => {
@@ -49,9 +49,8 @@ mod tests {
 	use crate::solver_repository::SolverService;
 	use oif_adapters::AdapterRegistry;
 	use oif_storage::{MemoryStore, Storage};
-	use oif_types::solvers::{AssetSource, SolverMetadata, SolverMetrics};
+	use oif_types::solvers::{AssetSource, SolverMetadata, SolverMetrics, SupportedAssets};
 	use oif_types::{Solver, SolverStatus};
-	use std::collections::HashMap;
 
 	/// Helper to create a test solver
 	fn create_test_solver() -> Solver {
@@ -64,10 +63,11 @@ mod tests {
 				name: Some("Test Solver".to_string()),
 				description: Some("Test solver for unit testing".to_string()),
 				version: None,
-				supported_routes: Vec::new(),
-				assets_source: AssetSource::AutoDiscovered, // Test solver for auto-discovery
+				supported_assets: SupportedAssets::Routes {
+					routes: Vec::new(),
+					source: AssetSource::AutoDiscovered,
+				},
 				headers: None,
-				config: HashMap::new(),
 			},
 			created_at: chrono::Utc::now(),
 			last_seen: None,

--- a/crates/service/src/jobs/handlers/solvers_fetch_assets.rs
+++ b/crates/service/src/jobs/handlers/solvers_fetch_assets.rs
@@ -49,9 +49,8 @@ mod tests {
 	use crate::solver_repository::SolverService;
 	use oif_adapters::AdapterRegistry;
 	use oif_storage::{MemoryStore, Storage};
-	use oif_types::solvers::{AssetSource, SolverMetadata, SolverMetrics};
+	use oif_types::solvers::{AssetSource, SolverMetadata, SolverMetrics, SupportedAssets};
 	use oif_types::{Solver, SolverStatus};
-	use std::collections::HashMap;
 
 	/// Helper to create a test solver
 	fn create_test_solver(solver_id: &str, status: SolverStatus) -> Solver {
@@ -65,10 +64,11 @@ mod tests {
 				description: Some("Test solver for unit testing".to_string()),
 				version: None,
 
-				assets_source: AssetSource::AutoDiscovered, // Test solver for auto-discovery
-				supported_routes: Vec::new(),
+				supported_assets: SupportedAssets::Routes {
+					routes: Vec::new(),
+					source: AssetSource::AutoDiscovered,
+				},
 				headers: None,
-				config: HashMap::new(),
 			},
 			created_at: chrono::Utc::now(),
 			last_seen: None,

--- a/crates/service/src/jobs/handlers/solvers_fetch_assets.rs
+++ b/crates/service/src/jobs/handlers/solvers_fetch_assets.rs
@@ -64,8 +64,9 @@ mod tests {
 				name: Some(format!("{} Solver", solver_id)),
 				description: Some("Test solver for unit testing".to_string()),
 				version: None,
-				supported_assets: vec![],
+
 				assets_source: AssetSource::AutoDiscovered, // Test solver for auto-discovery
+				supported_routes: Vec::new(),
 				headers: None,
 				config: HashMap::new(),
 			},

--- a/crates/service/src/jobs/handlers/solvers_health_check.rs
+++ b/crates/service/src/jobs/handlers/solvers_health_check.rs
@@ -49,9 +49,8 @@ mod tests {
 	use crate::solver_repository::SolverService;
 	use oif_adapters::AdapterRegistry;
 	use oif_storage::{MemoryStore, Storage};
-	use oif_types::solvers::{AssetSource, SolverMetadata, SolverMetrics};
+	use oif_types::solvers::{AssetSource, SolverMetadata, SolverMetrics, SupportedAssets};
 	use oif_types::{Solver, SolverStatus};
-	use std::collections::HashMap;
 
 	/// Helper to create a test solver
 	fn create_test_solver(solver_id: &str, status: SolverStatus) -> Solver {
@@ -65,10 +64,11 @@ mod tests {
 				description: Some("Test solver for unit testing".to_string()),
 				version: None,
 
-				assets_source: AssetSource::AutoDiscovered, // Test solver for auto-discovery
-				supported_routes: Vec::new(),
+				supported_assets: SupportedAssets::Routes {
+					routes: Vec::new(),
+					source: AssetSource::AutoDiscovered,
+				},
 				headers: None,
-				config: HashMap::new(),
 			},
 			created_at: chrono::Utc::now(),
 			last_seen: None,

--- a/crates/service/src/jobs/handlers/solvers_health_check.rs
+++ b/crates/service/src/jobs/handlers/solvers_health_check.rs
@@ -64,8 +64,9 @@ mod tests {
 				name: Some(format!("{} Solver", solver_id)),
 				description: Some("Test solver for unit testing".to_string()),
 				version: None,
-				supported_assets: vec![],
+
 				assets_source: AssetSource::AutoDiscovered, // Test solver for auto-discovery
+				supported_routes: Vec::new(),
 				headers: None,
 				config: HashMap::new(),
 			},

--- a/crates/service/src/jobs/tests.rs
+++ b/crates/service/src/jobs/tests.rs
@@ -38,8 +38,9 @@ fn create_test_services(
 
 	let solver_filter_service = Arc::new(SolverFilterService::new()) as Arc<dyn SolverFilterTrait>;
 
+	let storage = Arc::new(MemoryStore::new()) as Arc<dyn Storage>;
 	let aggregator_service = Arc::new(AggregatorService::with_config(
-		vec![], // empty solvers for tests
+		Arc::clone(&storage),
 		Arc::clone(&adapter_registry),
 		Arc::clone(&integrity_service),
 		solver_filter_service,

--- a/crates/service/src/solver_adapter.rs
+++ b/crates/service/src/solver_adapter.rs
@@ -11,7 +11,7 @@ use oif_adapters::AdapterRegistry;
 use oif_storage::Storage;
 use oif_types::adapters::models::{SubmitOrderRequest, SubmitOrderResponse};
 use oif_types::adapters::{GetOrderResponse, GetQuoteResponse};
-use oif_types::{Asset, GetQuoteRequest, Network, Solver, SolverAdapter, SolverRuntimeConfig};
+use oif_types::{AssetRoute, GetQuoteRequest, Network, Solver, SolverAdapter, SolverRuntimeConfig};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -57,8 +57,8 @@ pub trait SolverAdapterTrait: Send + Sync {
 	/// Get the supported networks for this solver
 	async fn get_supported_networks(&self) -> Result<Vec<Network>, SolverAdapterError>;
 
-	/// Get the supported assets for this solver
-	async fn get_supported_assets(&self) -> Result<Vec<Asset>, SolverAdapterError>;
+	/// Get the supported routes for this solver
+	async fn get_supported_routes(&self) -> Result<Vec<AssetRoute>, SolverAdapterError>;
 }
 
 /// Service for interacting with a specific solver through its adapter
@@ -187,11 +187,11 @@ impl SolverAdapterTrait for SolverAdapterService {
 			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
 	}
 
-	/// Get the supported assets for this solver
-	async fn get_supported_assets(&self) -> Result<Vec<Asset>, SolverAdapterError> {
+	/// Get the supported routes for this solver
+	async fn get_supported_routes(&self) -> Result<Vec<AssetRoute>, SolverAdapterError> {
 		let adapter = self.get_adapter();
 		adapter
-			.get_supported_assets(&self.config)
+			.get_supported_routes(&self.config)
 			.await
 			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
 	}

--- a/crates/service/src/solver_adapter.rs
+++ b/crates/service/src/solver_adapter.rs
@@ -11,7 +11,7 @@ use oif_adapters::AdapterRegistry;
 use oif_storage::Storage;
 use oif_types::adapters::models::{SubmitOrderRequest, SubmitOrderResponse};
 use oif_types::adapters::{GetOrderResponse, GetQuoteResponse};
-use oif_types::{AssetRoute, GetQuoteRequest, Solver, SolverAdapter, SolverRuntimeConfig};
+use oif_types::{GetQuoteRequest, Solver, SolverAdapter, SolverRuntimeConfig};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -54,8 +54,10 @@ pub trait SolverAdapterTrait: Send + Sync {
 	/// Get the solver ID this service is connected to
 	fn solver_id(&self) -> &str;
 
-	/// Get the supported routes for this solver
-	async fn get_supported_routes(&self) -> Result<Vec<AssetRoute>, SolverAdapterError>;
+	/// Get what assets/routes this solver supports
+	async fn get_supported_assets(
+		&self,
+	) -> Result<oif_types::SupportedAssetsData, SolverAdapterError>;
 }
 
 /// Service for interacting with a specific solver through its adapter
@@ -175,11 +177,13 @@ impl SolverAdapterTrait for SolverAdapterService {
 			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
 	}
 
-	/// Get the supported routes for this solver
-	async fn get_supported_routes(&self) -> Result<Vec<AssetRoute>, SolverAdapterError> {
+	/// Get what assets/routes this solver supports
+	async fn get_supported_assets(
+		&self,
+	) -> Result<oif_types::SupportedAssetsData, SolverAdapterError> {
 		let adapter = self.get_adapter();
 		adapter
-			.get_supported_routes(&self.config)
+			.get_supported_assets(&self.config)
 			.await
 			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
 	}

--- a/crates/service/src/solver_adapter.rs
+++ b/crates/service/src/solver_adapter.rs
@@ -11,7 +11,7 @@ use oif_adapters::AdapterRegistry;
 use oif_storage::Storage;
 use oif_types::adapters::models::{SubmitOrderRequest, SubmitOrderResponse};
 use oif_types::adapters::{GetOrderResponse, GetQuoteResponse};
-use oif_types::{AssetRoute, GetQuoteRequest, Network, Solver, SolverAdapter, SolverRuntimeConfig};
+use oif_types::{AssetRoute, GetQuoteRequest, Solver, SolverAdapter, SolverRuntimeConfig};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -53,9 +53,6 @@ pub trait SolverAdapterTrait: Send + Sync {
 
 	/// Get the solver ID this service is connected to
 	fn solver_id(&self) -> &str;
-
-	/// Get the supported networks for this solver
-	async fn get_supported_networks(&self) -> Result<Vec<Network>, SolverAdapterError>;
 
 	/// Get the supported routes for this solver
 	async fn get_supported_routes(&self) -> Result<Vec<AssetRoute>, SolverAdapterError>;
@@ -174,15 +171,6 @@ impl SolverAdapterTrait for SolverAdapterService {
 		let adapter = self.get_adapter();
 		adapter
 			.health_check(&self.config)
-			.await
-			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
-	}
-
-	/// Get the supported networks for this solver
-	async fn get_supported_networks(&self) -> Result<Vec<Network>, SolverAdapterError> {
-		let adapter = self.get_adapter();
-		adapter
-			.get_supported_networks(&self.config)
 			.await
 			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
 	}

--- a/crates/service/src/solver_adapter.rs
+++ b/crates/service/src/solver_adapter.rs
@@ -187,7 +187,6 @@ impl SolverAdapterTrait for SolverAdapterService {
 			.await
 			.map_err(|e| SolverAdapterError::Adapter(e.to_string()))
 	}
-
 	/// Get the solver ID this service is connected to
 	fn solver_id(&self) -> &str {
 		&self.solver.solver_id

--- a/crates/service/src/solver_filter.rs
+++ b/crates/service/src/solver_filter.rs
@@ -111,15 +111,13 @@ impl CompatibilityAnalyzer {
 				let is_valid_route = input.asset != output.asset || // Different assets
 					!input.asset.is_on_chain(output.asset.extract_chain_id().unwrap_or(0)); // Different chains
 
-				if is_valid_route {
-					if solver.supports_route(&input.asset, &output.asset) {
-						debug!(
-							"Solver '{}' can satisfy output {} via input {}",
-							solver.solver_id, output.asset, input.asset
-						);
-						output_satisfiable = true;
-						break; // Found at least one path to this output
-					}
+				if is_valid_route && solver.supports_route(&input.asset, &output.asset) {
+					debug!(
+						"Solver '{}' can satisfy output {} via input {}",
+						solver.solver_id, output.asset, input.asset
+					);
+					output_satisfiable = true;
+					break; // Found at least one path to this output
 				}
 			}
 

--- a/crates/service/src/solver_filter.rs
+++ b/crates/service/src/solver_filter.rs
@@ -121,19 +121,9 @@ impl CompatibilityAnalyzer {
 			let mut output_satisfiable = false;
 
 			for input in &request.available_inputs {
-				// For assets mode: check if solver supports both input and output assets
-				let input_supported = {
-					let input_chain_id = input.asset.extract_chain_id().unwrap_or(0);
-					let input_address = input.asset.extract_address();
-					solver.supports_asset_on_chain(input_chain_id, &input_address)
-				};
-				let output_supported = {
-					let output_chain_id = output.asset.extract_chain_id().unwrap_or(0);
-					let output_address = output.asset.extract_address();
-					solver.supports_asset_on_chain(output_chain_id, &output_address)
-				};
-
-				if input_supported && output_supported {
+				// For assets mode: check if solver supports the route from input to output asset
+				// The supports_route method handles assets mode correctly by checking both assets individually
+				if solver.supports_route(&input.asset, &output.asset) {
 					debug!(
 						"Solver '{}' (assets mode) can satisfy output {} via input {}",
 						solver.solver_id, output.asset, input.asset
@@ -503,11 +493,10 @@ mod tests {
 				let interop_addr =
 					InteropAddress::from_text(&format!("eip155:{}:{}", chain_id, address)).unwrap();
 				Asset::new(
-					interop_addr.extract_address(),
+					interop_addr,
 					format!("SYM{}", chain_id),
 					format!("Symbol {}", chain_id),
 					18,
-					chain_id,
 				)
 			})
 			.collect();

--- a/crates/service/src/solver_repository.rs
+++ b/crates/service/src/solver_repository.rs
@@ -288,8 +288,7 @@ impl SolverServiceTrait for SolverService {
 			SolverAdapterService::from_solver(solver, Arc::clone(&self.adapter_registry))
 				.map_err(|e| SolverServiceError::Storage(e.to_string()))?;
 
-		// Call standard adapter methods to get data
-		let networks_result = adapter_service.get_supported_networks().await;
+		// Call adapter method to get route data
 		let routes_result = adapter_service.get_supported_routes().await;
 
 		let mut has_updates = false;
@@ -308,26 +307,6 @@ impl SolverServiceTrait for SolverService {
 			Err(e) => {
 				warn!(
 					"Failed to auto-discover routes for solver {}: {}",
-					solver_id, e
-				);
-				// Continue with networks even if routes failed
-			},
-		}
-
-		// Business logic: Handle networks result (log for now)
-		match networks_result {
-			Ok(networks) => {
-				info!(
-					"Auto-discovered {} networks for solver: {}",
-					networks.len(),
-					solver_id
-				);
-				debug!("Networks for solver {}: {:?}", solver_id, networks);
-				// Future: Store networks in solver metadata if needed
-			},
-			Err(e) => {
-				warn!(
-					"Failed to auto-discover networks for solver {}: {}",
 					solver_id, e
 				);
 			},

--- a/crates/types/src/adapters/mod.rs
+++ b/crates/types/src/adapters/mod.rs
@@ -6,6 +6,7 @@ pub mod errors;
 pub mod models;
 pub mod traits;
 
+pub use crate::models::SupportedAssetsData;
 pub use errors::{AdapterError, AdapterFactoryError, AdapterValidationError};
 pub use models::{
 	AdapterQuote, AssetAmount, AvailableInput, GetOrderResponse, GetQuoteRequest, GetQuoteResponse,

--- a/crates/types/src/adapters/models.rs
+++ b/crates/types/src/adapters/models.rs
@@ -101,6 +101,11 @@ pub struct AdapterQuote {
 	pub quote_id: String,
 	/// Quote provider identifier
 	pub provider: String,
+	/// Adapter-specific metadata for additional context and execution details
+	/// This field allows each adapter to include protocol-specific information
+	/// that consumers might need for order execution or additional context
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub metadata: Option<serde_json::Value>,
 }
 
 /// Quote details matching the request structure

--- a/crates/types/src/adapters/traits.rs
+++ b/crates/types/src/adapters/traits.rs
@@ -6,7 +6,7 @@ use crate::{
 		models::{SubmitOrderRequest, SubmitOrderResponse},
 		AdapterError, GetOrderResponse,
 	},
-	models::{Asset, Network},
+	models::{AssetRoute, Network},
 };
 use crate::{Adapter, GetQuoteRequest, GetQuoteResponse};
 use async_trait::async_trait;
@@ -80,12 +80,19 @@ pub trait SolverAdapter: Send + Sync + Debug {
 		config: &SolverRuntimeConfig,
 	) -> AdapterResult<Vec<Network>>;
 
-	/// Get the list of assets supported on a specific network
+	/// Get the list of supported asset routes (origin -> destination pairs)
 	///
-	/// Returns the tokens/assets that this adapter can handle on the given network.
-	/// Each asset includes contract address, symbol, name, decimals, and chain ID.
-	async fn get_supported_assets(&self, config: &SolverRuntimeConfig)
-		-> AdapterResult<Vec<Asset>>;
+	/// Returns the specific asset conversion routes that this adapter can handle.
+	/// Routes provide precise compatibility checking for cross-chain operations.
+	/// For example, an adapter might support Base USDC → Ethereum USDC but not the reverse.
+	///
+	/// All adapters must implement this method to provide route information.
+	/// For adapters that only expose asset lists (like some legacy APIs),
+	/// generate cross-chain routes from the available assets.
+	async fn get_supported_routes(
+		&self,
+		config: &SolverRuntimeConfig,
+	) -> AdapterResult<Vec<AssetRoute>>;
 
 	/// Get human-readable name for this adapter
 	fn name(&self) -> &str {

--- a/crates/types/src/adapters/traits.rs
+++ b/crates/types/src/adapters/traits.rs
@@ -6,7 +6,7 @@ use crate::{
 		models::{SubmitOrderRequest, SubmitOrderResponse},
 		AdapterError, GetOrderResponse,
 	},
-	models::{AssetRoute, Network},
+	models::AssetRoute,
 };
 use crate::{Adapter, GetQuoteRequest, GetQuoteResponse};
 use async_trait::async_trait;
@@ -70,15 +70,6 @@ pub trait SolverAdapter: Send + Sync + Debug {
 			adapter_id: self.id().to_string(),
 		})
 	}
-
-	/// Get the list of blockchain networks supported by this adapter
-	///
-	/// Returns the networks (chains) that this adapter can process transactions on.
-	/// Each network includes chain ID, name, and testnet status.
-	async fn get_supported_networks(
-		&self,
-		config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Network>>;
 
 	/// Get the list of supported asset routes (origin -> destination pairs)
 	///

--- a/crates/types/src/adapters/traits.rs
+++ b/crates/types/src/adapters/traits.rs
@@ -1,13 +1,11 @@
 //! Core adapter traits for user implementations
 
 use super::{AdapterResult, SolverRuntimeConfig};
-use crate::{
-	adapters::{
-		models::{SubmitOrderRequest, SubmitOrderResponse},
-		AdapterError, GetOrderResponse,
-	},
-	models::AssetRoute,
+use crate::adapters::{
+	models::{SubmitOrderRequest, SubmitOrderResponse},
+	AdapterError, GetOrderResponse,
 };
+use crate::models::SupportedAssetsData;
 use crate::{Adapter, GetQuoteRequest, GetQuoteResponse};
 use async_trait::async_trait;
 use std::fmt::Debug;
@@ -71,19 +69,18 @@ pub trait SolverAdapter: Send + Sync + Debug {
 		})
 	}
 
-	/// Get the list of supported asset routes (origin -> destination pairs)
+	/// Get what assets/routes this adapter supports
 	///
-	/// Returns the specific asset conversion routes that this adapter can handle.
-	/// Routes provide precise compatibility checking for cross-chain operations.
-	/// For example, an adapter might support Base USDC → Ethereum USDC but not the reverse.
+	/// Each adapter chooses its own mode:
+	/// - Assets mode: Simple any-to-any within asset list (including same-chain)
+	/// - Routes mode: Precise origin->destination pairs
 	///
-	/// All adapters must implement this method to provide route information.
-	/// For adapters that only expose asset lists (like some legacy APIs),
-	/// generate cross-chain routes from the available assets.
-	async fn get_supported_routes(
+	/// All adapters must implement this method to provide support information.
+	/// The service layer will automatically set the source as AutoDiscovered.
+	async fn get_supported_assets(
 		&self,
 		config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<AssetRoute>>;
+	) -> AdapterResult<SupportedAssetsData>;
 
 	/// Get human-readable name for this adapter
 	fn name(&self) -> &str {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -39,7 +39,9 @@ pub use adapters::{
 	AdapterQuote, AvailableInput, GetQuoteRequest, GetQuoteResponse, QuoteDetails, QuoteOrder,
 	QuotePreference, RequestedOutput, SettlementType, SignatureType,
 };
-pub use models::{Asset, InteropAddress, Lock, Network, SecretString, U256};
+pub use models::{
+	Asset, AssetRoute, AssetRouteResponse, InteropAddress, Lock, Network, SecretString, U256,
+};
 
 pub use orders::{
 	Order, OrderError, OrderRequest, OrderResponse, OrderStatus, OrderStorage,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -40,7 +40,8 @@ pub use adapters::{
 	QuotePreference, RequestedOutput, SettlementType, SignatureType,
 };
 pub use models::{
-	Asset, AssetRoute, AssetRouteResponse, InteropAddress, Lock, Network, SecretString, U256,
+	Asset, AssetRoute, AssetRouteResponse, InteropAddress, Lock, Network, SecretString,
+	SupportedAssetsData, U256,
 };
 
 pub use orders::{

--- a/crates/types/src/models/asset.rs
+++ b/crates/types/src/models/asset.rs
@@ -1,34 +1,56 @@
 //! Blockchain asset/token models
 
+use crate::models::InteropAddress;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
-/// Supported blockchain asset/token
+/// Supported blockchain asset/token (internal model with InteropAddress)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct Asset {
-	/// Contract address (use "0x0" for native tokens)
-	pub address: String,
+	/// Asset address in ERC-7930 interoperable format
+	pub address: InteropAddress,
 	/// Token symbol (e.g., "ETH", "USDC", "WBTC")
 	pub symbol: String,
 	/// Human-readable name (e.g., "Ethereum", "USD Coin")
 	pub name: String,
 	/// Number of decimal places
 	pub decimals: u8,
-	/// Chain ID where this asset exists
-	pub chain_id: u64,
 }
 
 impl Asset {
-	pub fn new(address: String, symbol: String, name: String, decimals: u8, chain_id: u64) -> Self {
+	/// Create a new asset from InteropAddress
+	pub fn new(address: InteropAddress, symbol: String, name: String, decimals: u8) -> Self {
 		Self {
 			address,
 			symbol,
 			name,
 			decimals,
-			chain_id,
 		}
+	}
+
+	/// Create asset from plain chain_id and address (for convenience)
+	pub fn from_chain_and_address(
+		chain_id: u64,
+		address: String,
+		symbol: String,
+		name: String,
+		decimals: u8,
+	) -> Result<Self, crate::quotes::errors::QuoteValidationError> {
+		let interop_address =
+			InteropAddress::from_text(&format!("eip155:{}:{}", chain_id, address))?;
+		Ok(Self::new(interop_address, symbol, name, decimals))
+	}
+
+	/// Extract chain ID
+	pub fn chain_id(&self) -> Result<u64, crate::quotes::errors::QuoteValidationError> {
+		self.address.extract_chain_id()
+	}
+
+	/// Extract plain address
+	pub fn plain_address(&self) -> String {
+		self.address.extract_address()
 	}
 }
 
@@ -36,105 +58,115 @@ impl Asset {
 impl Asset {
 	// Ethereum assets
 	pub fn eth() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			1,
 			"0x0000000000000000000000000000000000000000".to_string(),
 			"ETH".to_string(),
 			"Ethereum".to_string(),
 			18,
-			1,
 		)
+		.expect("Valid ETH asset")
 	}
 
 	pub fn usdc_ethereum() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			1,
 			"0xA0b86a33E6441E7C81F7C93451777f5F4dE78e86".to_string(),
 			"USDC".to_string(),
 			"USD Coin".to_string(),
 			6,
-			1,
 		)
+		.expect("Valid USDC asset")
 	}
 
 	pub fn usdt_ethereum() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			1,
 			"0xdAC17F958D2ee523a2206206994597C13D831ec7".to_string(),
 			"USDT".to_string(),
 			"Tether USD".to_string(),
 			6,
-			1,
 		)
+		.expect("Valid USDT asset")
 	}
 
 	pub fn wbtc_ethereum() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			1,
 			"0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599".to_string(),
 			"WBTC".to_string(),
 			"Wrapped Bitcoin".to_string(),
 			8,
-			1,
 		)
+		.expect("Valid WBTC asset")
 	}
 
 	// Polygon assets
 	pub fn matic() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			137,
 			"0x0000000000000000000000000000000000001010".to_string(),
 			"MATIC".to_string(),
 			"Polygon".to_string(),
 			18,
-			137,
 		)
+		.expect("Valid MATIC asset")
 	}
 
 	pub fn usdc_polygon() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			137,
 			"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174".to_string(),
 			"USDC".to_string(),
 			"USD Coin".to_string(),
 			6,
-			137,
 		)
+		.expect("Valid USDC Polygon asset")
 	}
 
 	// BSC assets
 	pub fn bnb() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			56,
 			"0x0000000000000000000000000000000000000000".to_string(),
 			"BNB".to_string(),
 			"Binance Coin".to_string(),
 			18,
-			56,
 		)
+		.expect("Valid BNB asset")
 	}
 
 	pub fn usdc_bsc() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			56,
 			"0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d".to_string(),
 			"USDC".to_string(),
 			"USD Coin".to_string(),
 			18,
-			56,
 		)
+		.expect("Valid USDC BSC asset")
 	}
 
 	// Base assets
 	pub fn eth_base() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			8453,
 			"0x0000000000000000000000000000000000000000".to_string(),
 			"ETH".to_string(),
 			"Ethereum".to_string(),
 			18,
-			8453,
 		)
+		.expect("Valid ETH Base asset")
 	}
 
 	pub fn usdc_base() -> Self {
-		Self::new(
+		Self::from_chain_and_address(
+			8453,
 			"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913".to_string(),
 			"USDC".to_string(),
 			"USD Coin".to_string(),
 			6,
-			8453,
 		)
+		.expect("Valid USDC Base asset")
 	}
 }

--- a/crates/types/src/models/asset_route.rs
+++ b/crates/types/src/models/asset_route.rs
@@ -6,8 +6,6 @@
 
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "openapi")]
-use serde_json::json;
-#[cfg(feature = "openapi")]
 use utoipa::ToSchema;
 
 use super::InteropAddress;

--- a/crates/types/src/models/asset_route.rs
+++ b/crates/types/src/models/asset_route.rs
@@ -1,0 +1,397 @@
+//! Asset route models for cross-chain transaction routing
+//!
+//! This module defines models for representing supported asset conversion routes
+//! between different chains and tokens. Routes provide more precise compatibility
+//! checking than just checking if individual assets are supported.
+
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "openapi")]
+use serde_json::json;
+#[cfg(feature = "openapi")]
+use utoipa::ToSchema;
+
+use super::InteropAddress;
+
+/// Represents a supported asset conversion route
+///
+/// An asset route defines a specific conversion path from an origin asset
+/// on one chain to a destination asset on another (or the same) chain.
+/// This provides more precise compatibility checking than just checking
+/// if individual assets are supported.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[serde(rename_all = "camelCase")]
+pub struct AssetRoute {
+	/// Origin asset (includes chain and token address)
+	pub origin_asset: InteropAddress,
+
+	/// Optional origin token symbol for readability and debugging (e.g., "WETH", "USDC")
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub origin_token_symbol: Option<String>,
+
+	/// Destination asset (includes chain and token address)  
+	pub destination_asset: InteropAddress,
+
+	/// Optional destination token symbol for readability and debugging (e.g., "WETH", "USDC")
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub destination_token_symbol: Option<String>,
+
+	/// Optional route-specific metadata (fees, limits, execution time, etc.)
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub metadata: Option<serde_json::Value>,
+}
+
+impl AssetRoute {
+	/// Create a new asset route
+	pub fn new(origin_asset: InteropAddress, destination_asset: InteropAddress) -> Self {
+		Self {
+			origin_asset,
+			origin_token_symbol: None,
+			destination_asset,
+			destination_token_symbol: None,
+			metadata: None,
+		}
+	}
+
+	/// Create a new asset route with metadata
+	pub fn with_metadata(
+		origin_asset: InteropAddress,
+		destination_asset: InteropAddress,
+		metadata: serde_json::Value,
+	) -> Self {
+		Self {
+			origin_asset,
+			origin_token_symbol: None,
+			destination_asset,
+			destination_token_symbol: None,
+			metadata: Some(metadata),
+		}
+	}
+
+	/// Create a new asset route with symbols
+	pub fn with_symbols(
+		origin_asset: InteropAddress,
+		origin_symbol: String,
+		destination_asset: InteropAddress,
+		destination_symbol: String,
+	) -> Self {
+		Self {
+			origin_asset,
+			origin_token_symbol: Some(origin_symbol),
+			destination_asset,
+			destination_token_symbol: Some(destination_symbol),
+			metadata: None,
+		}
+	}
+
+	/// Create a new asset route with symbols and metadata
+	pub fn with_symbols_and_metadata(
+		origin_asset: InteropAddress,
+		origin_symbol: String,
+		destination_asset: InteropAddress,
+		destination_symbol: String,
+		metadata: serde_json::Value,
+	) -> Self {
+		Self {
+			origin_asset,
+			origin_token_symbol: Some(origin_symbol),
+			destination_asset,
+			destination_token_symbol: Some(destination_symbol),
+			metadata: Some(metadata),
+		}
+	}
+
+	/// Add origin token symbol
+	pub fn with_origin_symbol(mut self, symbol: String) -> Self {
+		self.origin_token_symbol = Some(symbol);
+		self
+	}
+
+	/// Add destination token symbol
+	pub fn with_destination_symbol(mut self, symbol: String) -> Self {
+		self.destination_token_symbol = Some(symbol);
+		self
+	}
+
+	/// Check if this route matches the given origin and destination assets
+	pub fn matches(&self, origin: &InteropAddress, destination: &InteropAddress) -> bool {
+		self.origin_asset == *origin && self.destination_asset == *destination
+	}
+
+	/// Check if this route involves the same chain (same-chain swap)
+	pub fn is_same_chain(&self) -> bool {
+		self.origin_asset.extract_chain_id().ok() == self.destination_asset.extract_chain_id().ok()
+	}
+
+	/// Check if this route is cross-chain
+	pub fn is_cross_chain(&self) -> bool {
+		!self.is_same_chain()
+	}
+
+	/// Get the origin chain ID
+	pub fn origin_chain_id(&self) -> Result<u64, String> {
+		self.origin_asset
+			.extract_chain_id()
+			.map_err(|e| e.to_string())
+	}
+
+	/// Get the destination chain ID  
+	pub fn destination_chain_id(&self) -> Result<u64, String> {
+		self.destination_asset
+			.extract_chain_id()
+			.map_err(|e| e.to_string())
+	}
+
+	/// Get origin token address
+	pub fn origin_address(&self) -> String {
+		self.origin_asset.extract_address()
+	}
+
+	/// Get destination token address
+	pub fn destination_address(&self) -> String {
+		self.destination_asset.extract_address()
+	}
+}
+
+/// API response format for asset routes with separate chain ID and address fields
+///
+/// This provides a more readable format for API consumers compared to the
+/// internal InteropAddress format used in the domain model.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "openapi", derive(ToSchema))]
+#[cfg_attr(feature = "openapi", schema(example = json!({
+    "originChainId": 1,
+    "originTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+    "originTokenSymbol": "WETH",
+    "destinationChainId": 10,
+    "destinationTokenAddress": "0x4200000000000000000000000000000000000006",
+    "destinationTokenSymbol": "WETH",
+    "metadata": {
+        "isNative": false,
+        "source": "across-api",
+        "estimatedFee": "0.001",
+        "estimatedTime": 120
+    }
+})))]
+#[serde(rename_all = "camelCase")]
+pub struct AssetRouteResponse {
+	/// Origin chain ID
+	pub origin_chain_id: u64,
+
+	/// Origin token contract address
+	pub origin_token_address: String,
+
+	/// Optional origin token symbol for readability (e.g., "WETH", "USDC")
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub origin_token_symbol: Option<String>,
+
+	/// Destination chain ID
+	pub destination_chain_id: u64,
+
+	/// Destination token contract address
+	pub destination_token_address: String,
+
+	/// Optional destination token symbol for readability (e.g., "WETH", "USDC")
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub destination_token_symbol: Option<String>,
+
+	/// Optional route-specific metadata (fees, limits, execution time, etc.)
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub metadata: Option<serde_json::Value>,
+}
+
+/// Convert from domain AssetRoute to API AssetRouteResponse
+impl TryFrom<&AssetRoute> for AssetRouteResponse {
+	type Error = String;
+
+	fn try_from(route: &AssetRoute) -> Result<Self, Self::Error> {
+		Ok(Self {
+			origin_chain_id: route.origin_chain_id()?,
+			origin_token_address: route.origin_address(),
+			origin_token_symbol: route.origin_token_symbol.clone(),
+			destination_chain_id: route.destination_chain_id()?,
+			destination_token_address: route.destination_address(),
+			destination_token_symbol: route.destination_token_symbol.clone(),
+			metadata: route.metadata.clone(),
+		})
+	}
+}
+
+/// Convert from domain AssetRoute to API AssetRouteResponse (owned)
+impl TryFrom<AssetRoute> for AssetRouteResponse {
+	type Error = String;
+
+	fn try_from(route: AssetRoute) -> Result<Self, Self::Error> {
+		AssetRouteResponse::try_from(&route)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::InteropAddress;
+
+	fn create_test_route() -> AssetRoute {
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.unwrap(); // WETH on Ethereum
+		let destination = InteropAddress::from_chain_and_address(
+			10,
+			"0x4200000000000000000000000000000000000006",
+		)
+		.unwrap(); // WETH on Optimism
+		AssetRoute::new(origin, destination)
+	}
+
+	#[test]
+	fn test_asset_route_creation() {
+		let route = create_test_route();
+
+		assert_eq!(route.origin_chain_id().unwrap(), 1);
+		assert_eq!(route.destination_chain_id().unwrap(), 10);
+		assert!(route.is_cross_chain());
+		assert!(!route.is_same_chain());
+		assert!(route.metadata.is_none());
+	}
+
+	#[test]
+	fn test_asset_route_with_metadata() {
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.unwrap();
+		let destination = InteropAddress::from_chain_and_address(
+			10,
+			"0x4200000000000000000000000000000000000006",
+		)
+		.unwrap();
+		let metadata = serde_json::json!({
+			"min_amount": "1000000000000000000",
+			"max_amount": "100000000000000000000",
+			"estimated_fee": "50000000000000000"
+		});
+
+		let route = AssetRoute::with_metadata(origin, destination, metadata.clone());
+
+		assert!(route.metadata.is_some());
+		assert_eq!(route.metadata.unwrap(), metadata);
+		assert!(route.origin_token_symbol.is_none());
+		assert!(route.destination_token_symbol.is_none());
+	}
+
+	#[test]
+	fn test_asset_route_with_symbols() {
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.unwrap();
+		let destination = InteropAddress::from_chain_and_address(
+			10,
+			"0x4200000000000000000000000000000000000006",
+		)
+		.unwrap();
+
+		let route =
+			AssetRoute::with_symbols(origin, "WETH".to_string(), destination, "WETH".to_string());
+
+		assert_eq!(route.origin_token_symbol, Some("WETH".to_string()));
+		assert_eq!(route.destination_token_symbol, Some("WETH".to_string()));
+		assert!(route.metadata.is_none());
+	}
+
+	#[test]
+	fn test_asset_route_builder_pattern() {
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0")
+				.unwrap();
+		let destination = InteropAddress::from_chain_and_address(
+			137,
+			"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+		)
+		.unwrap();
+
+		let route = AssetRoute::new(origin, destination)
+			.with_origin_symbol("USDC".to_string())
+			.with_destination_symbol("USDC".to_string());
+
+		assert_eq!(route.origin_token_symbol, Some("USDC".to_string()));
+		assert_eq!(route.destination_token_symbol, Some("USDC".to_string()));
+		assert!(route.is_cross_chain());
+	}
+
+	#[test]
+	fn test_route_matching() {
+		let route = create_test_route();
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.unwrap();
+		let destination = InteropAddress::from_chain_and_address(
+			10,
+			"0x4200000000000000000000000000000000000006",
+		)
+		.unwrap();
+		let wrong_destination = InteropAddress::from_chain_and_address(
+			137,
+			"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+		)
+		.unwrap();
+
+		assert!(route.matches(&origin, &destination));
+		assert!(!route.matches(&origin, &wrong_destination));
+	}
+
+	#[test]
+	fn test_same_chain_detection() {
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.unwrap(); // WETH
+		let destination =
+			InteropAddress::from_chain_and_address(1, "0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0")
+				.unwrap(); // USDC
+		let same_chain_route = AssetRoute::new(origin, destination);
+
+		assert!(same_chain_route.is_same_chain());
+		assert!(!same_chain_route.is_cross_chain());
+	}
+
+	#[test]
+	fn test_asset_route_response_conversion() {
+		let origin =
+			InteropAddress::from_chain_and_address(1, "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+				.unwrap();
+		let destination = InteropAddress::from_chain_and_address(
+			137,
+			"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+		)
+		.unwrap();
+
+		let metadata = serde_json::json!({
+			"isNative": false,
+			"source": "config",
+			"minAmount": "1000000"
+		});
+
+		let route = AssetRoute::with_symbols_and_metadata(
+			origin,
+			"WETH".to_string(),
+			destination,
+			"USDC".to_string(),
+			metadata.clone(),
+		);
+
+		let response = AssetRouteResponse::try_from(&route).unwrap();
+
+		// Verify the readable format
+		assert_eq!(response.origin_chain_id, 1);
+		assert_eq!(
+			response.origin_token_address.to_lowercase(),
+			"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+		);
+		assert_eq!(response.origin_token_symbol, Some("WETH".to_string()));
+		assert_eq!(response.destination_chain_id, 137);
+		assert_eq!(
+			response.destination_token_address.to_lowercase(),
+			"0x2791bca1f2de4661ed88a30c99a7a9449aa84174"
+		);
+		assert_eq!(response.destination_token_symbol, Some("USDC".to_string()));
+		assert_eq!(response.metadata, Some(metadata));
+	}
+}

--- a/crates/types/src/models/asset_route.rs
+++ b/crates/types/src/models/asset_route.rs
@@ -82,6 +82,38 @@ impl AssetRoute {
 		}
 	}
 
+	/// Builder method to add symbols to an existing route
+	pub fn add_symbols(
+		mut self,
+		origin_symbol: Option<String>,
+		destination_symbol: Option<String>,
+	) -> Self {
+		self.origin_token_symbol = origin_symbol;
+		self.destination_token_symbol = destination_symbol;
+		self
+	}
+
+	/// Builder method to add metadata to an existing route
+	pub fn add_metadata(mut self, metadata: Option<serde_json::Value>) -> Self {
+		self.metadata = metadata;
+		self
+	}
+
+	/// Create asset route from plain chain IDs and addresses
+	pub fn from_chain_and_addresses(
+		origin_chain_id: u64,
+		origin_address: String,
+		destination_chain_id: u64,
+		destination_address: String,
+	) -> Result<Self, crate::quotes::errors::QuoteValidationError> {
+		let origin_asset =
+			InteropAddress::from_chain_and_address(origin_chain_id, &origin_address)?;
+		let destination_asset =
+			InteropAddress::from_chain_and_address(destination_chain_id, &destination_address)?;
+
+		Ok(Self::new(origin_asset, destination_asset))
+	}
+
 	/// Create a new asset route with symbols and metadata
 	pub fn with_symbols_and_metadata(
 		origin_asset: InteropAddress,

--- a/crates/types/src/models/interop_address.rs
+++ b/crates/types/src/models/interop_address.rs
@@ -27,7 +27,7 @@ use utoipa::ToSchema;
 const CAIP_EIP155: [u8; 2] = [0x00, 0x00]; // Alternative EIP-155 (default for this system)
 
 /// ERC-7930 Interoperable Address
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "openapi", derive(ToSchema))]
 pub struct InteropAddress {
 	version: u8,              // Version number (e.g., 1) - 1 byte per ERC-7930

--- a/crates/types/src/models/mod.rs
+++ b/crates/types/src/models/mod.rs
@@ -1,6 +1,7 @@
 //! Shared domain models used across adapters, solvers, and other components
 
 pub mod asset;
+pub mod asset_route;
 pub mod health;
 pub mod interop_address;
 pub mod lock;
@@ -9,6 +10,7 @@ pub mod secret_string;
 pub mod u256;
 
 pub use asset::Asset;
+pub use asset_route::{AssetRoute, AssetRouteResponse};
 pub use health::{HealthResponse, SolverStats, StorageHealthInfo};
 pub use interop_address::InteropAddress;
 pub use lock::Lock;

--- a/crates/types/src/models/mod.rs
+++ b/crates/types/src/models/mod.rs
@@ -17,3 +17,12 @@ pub use lock::Lock;
 pub use network::Network;
 pub use secret_string::SecretString;
 pub use u256::U256;
+
+/// Data returned by adapters for supported assets/routes (without source info)
+#[derive(Debug, Clone, PartialEq)]
+pub enum SupportedAssetsData {
+	/// Asset-based: supports any-to-any within asset list (including same-chain)
+	Assets(Vec<Asset>),
+	/// Route-based: supports specific origin->destination pairs
+	Routes(Vec<AssetRoute>),
+}

--- a/crates/types/src/quotes/response.rs
+++ b/crates/types/src/quotes/response.rs
@@ -92,6 +92,12 @@ pub struct QuoteResponse {
 	/// HMAC-SHA256 integrity checksum for quote verification
 	/// This ensures the quote originated from the aggregator service
 	pub integrity_checksum: String,
+
+	/// Adapter-specific metadata for additional context and execution details
+	/// This field allows each adapter to include protocol-specific information
+	/// that consumers might need for order execution or additional context
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub metadata: Option<serde_json::Value>,
 }
 
 /// Collection of quotes response for API endpoints
@@ -212,6 +218,7 @@ impl TryFrom<Quote> for QuoteResponse {
 			eta: quote.eta,
 			provider: quote.provider,
 			integrity_checksum: quote.integrity_checksum,
+			metadata: quote.metadata,
 		})
 	}
 }
@@ -230,6 +237,7 @@ impl TryFrom<QuoteResponse> for Quote {
 			eta: response.eta,
 			provider: response.provider,
 			integrity_checksum: response.integrity_checksum,
+			metadata: response.metadata,
 		})
 	}
 }

--- a/crates/types/src/solvers/config.rs
+++ b/crates/types/src/solvers/config.rs
@@ -85,13 +85,14 @@ impl TryFrom<AssetConfig> for crate::models::Asset {
 		let symbol = config.symbol.unwrap_or_else(|| "UNKNOWN".to_string());
 		let name = symbol.clone();
 
-		Ok(crate::models::Asset {
-			address: config.address,
+		crate::models::Asset::from_chain_and_address(
+			config.chain_id,
+			config.address,
 			symbol,
 			name,
-			decimals: 18, // Default to 18 decimals (most common)
-			chain_id: config.chain_id,
-		})
+			18, // Default to 18 decimals (most common)
+		)
+		.map_err(|e| format!("Failed to create asset: {}", e))
 	}
 }
 

--- a/crates/types/src/solvers/config.rs
+++ b/crates/types/src/solvers/config.rs
@@ -5,7 +5,130 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use super::{Solver, SolverValidationError, SolverValidationResult};
-use crate::models::Asset;
+use crate::models::{AssetRoute, InteropAddress};
+
+/// User-friendly route configuration for config files
+///
+/// This format is more readable in JSON config files than the full InteropAddress format.
+/// It gets converted to AssetRoute during solver creation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RouteConfig {
+	/// Origin chain ID (e.g., 1 for Ethereum)
+	pub origin_chain_id: u64,
+
+	/// Origin token address (e.g., "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
+	pub origin_token_address: String,
+
+	/// Optional origin token symbol for readability (e.g., "WETH", "USDC")
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub origin_token_symbol: Option<String>,
+
+	/// Destination chain ID (e.g., 10 for Optimism)
+	pub destination_chain_id: u64,
+
+	/// Destination token address (e.g., "0x4200000000000000000000000000000000000006")
+	pub destination_token_address: String,
+
+	/// Optional destination token symbol for readability (e.g., "WETH", "USDC")
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub destination_token_symbol: Option<String>,
+
+	/// Optional route-specific metadata (fees, limits, etc.)
+	#[serde(skip_serializing_if = "Option::is_none")]
+	pub metadata: Option<serde_json::Value>,
+}
+
+/// Convert from config RouteConfig to domain AssetRoute
+impl TryFrom<RouteConfig> for AssetRoute {
+	type Error = String;
+
+	fn try_from(config: RouteConfig) -> Result<Self, Self::Error> {
+		let origin_asset = InteropAddress::from_chain_and_address(
+			config.origin_chain_id,
+			&config.origin_token_address,
+		)
+		.map_err(|e| format!("Invalid origin asset: {}", e))?;
+
+		let destination_asset = InteropAddress::from_chain_and_address(
+			config.destination_chain_id,
+			&config.destination_token_address,
+		)
+		.map_err(|e| format!("Invalid destination asset: {}", e))?;
+
+		// Build AssetRoute with symbols and metadata
+		let mut route = AssetRoute::new(origin_asset, destination_asset);
+
+		if let Some(origin_symbol) = config.origin_token_symbol {
+			route = route.with_origin_symbol(origin_symbol);
+		}
+
+		if let Some(destination_symbol) = config.destination_token_symbol {
+			route = route.with_destination_symbol(destination_symbol);
+		}
+
+		if let Some(metadata) = config.metadata {
+			route.metadata = Some(metadata);
+		}
+
+		Ok(route)
+	}
+}
+
+/// Convert from domain AssetRoute to config RouteConfig (for serialization back to config)
+impl TryFrom<&AssetRoute> for RouteConfig {
+	type Error = String;
+
+	fn try_from(route: &AssetRoute) -> Result<Self, Self::Error> {
+		Ok(Self {
+			origin_chain_id: route.origin_chain_id()?,
+			origin_token_address: route.origin_address(),
+			origin_token_symbol: route.origin_token_symbol.clone(),
+			destination_chain_id: route.destination_chain_id()?,
+			destination_token_address: route.destination_address(),
+			destination_token_symbol: route.destination_token_symbol.clone(),
+			metadata: route.metadata.clone(),
+		})
+	}
+}
+
+impl RouteConfig {
+	/// Create a new route config with all fields
+	pub fn new(
+		origin_chain_id: u64,
+		origin_token_address: String,
+		destination_chain_id: u64,
+		destination_token_address: String,
+	) -> Self {
+		Self {
+			origin_chain_id,
+			origin_token_address,
+			origin_token_symbol: None,
+			destination_chain_id,
+			destination_token_address,
+			destination_token_symbol: None,
+			metadata: None,
+		}
+	}
+
+	/// Add origin token symbol for readability
+	pub fn with_origin_symbol(mut self, symbol: String) -> Self {
+		self.origin_token_symbol = Some(symbol);
+		self
+	}
+
+	/// Add destination token symbol for readability
+	pub fn with_destination_symbol(mut self, symbol: String) -> Self {
+		self.destination_token_symbol = Some(symbol);
+		self
+	}
+
+	/// Add metadata
+	pub fn with_metadata(mut self, metadata: serde_json::Value) -> Self {
+		self.metadata = Some(metadata);
+		self
+	}
+}
 
 /// Solver configuration from external sources (config files, API)
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,8 +157,9 @@ pub struct SolverConfig {
 	/// API version
 	pub version: Option<String>,
 
-	/// Supported assets/tokens
-	pub supported_assets: Option<Vec<Asset>>,
+	/// Supported routes (origin -> destination asset pairs)
+	/// Uses user-friendly format with chain IDs and addresses
+	pub supported_routes: Option<Vec<RouteConfig>>,
 
 	/// Solver-specific configuration
 	pub config: Option<HashMap<String, serde_json::Value>>,
@@ -93,7 +217,7 @@ impl SolverConfig {
 			name: None,
 			description: None,
 			version: None,
-			supported_assets: None,
+			supported_routes: None,
 			config: None,
 		}
 	}
@@ -108,8 +232,8 @@ impl SolverConfig {
 		self
 	}
 
-	pub fn with_assets(mut self, assets: Vec<Asset>) -> Self {
-		self.supported_assets = Some(assets);
+	pub fn with_routes(mut self, routes: Vec<RouteConfig>) -> Self {
+		self.supported_routes = Some(routes);
 		self
 	}
 
@@ -219,8 +343,18 @@ impl TryFrom<SolverConfig> for Solver {
 			solver = solver.with_version(version);
 		}
 
-		if let Some(assets) = config.supported_assets {
-			solver = solver.with_assets(assets);
+		if let Some(route_configs) = config.supported_routes {
+			// Convert RouteConfig to AssetRoute using TryFrom
+			let routes: Result<Vec<AssetRoute>, _> = route_configs
+				.into_iter()
+				.map(AssetRoute::try_from)
+				.collect();
+
+			let routes = routes.map_err(|e| SolverValidationError::InvalidConfiguration {
+				reason: format!("Invalid route in supported_routes: {}", e),
+			})?;
+
+			solver = solver.with_routes(routes);
 		}
 
 		if let Some(headers) = config.headers {
@@ -242,6 +376,75 @@ impl TryFrom<SolverConfig> for Solver {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	#[test]
+	fn test_route_config_conversion() {
+		// Test RouteConfig with symbols
+		let route_config = RouteConfig::new(
+			1,                                                        // Ethereum
+			"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(), // WETH
+			10,                                                       // Optimism
+			"0x4200000000000000000000000000000000000006".to_string(), // WETH
+		)
+		.with_origin_symbol("WETH".to_string())
+		.with_destination_symbol("WETH".to_string())
+		.with_metadata(serde_json::json!({
+			"min_amount": "1000000000000000000",
+			"max_amount": "100000000000000000000"
+		}));
+
+		// Convert to AssetRoute using TryFrom
+		let asset_route = AssetRoute::try_from(route_config).unwrap();
+
+		assert_eq!(asset_route.origin_chain_id().unwrap(), 1);
+		assert_eq!(asset_route.destination_chain_id().unwrap(), 10);
+		assert!(asset_route.is_cross_chain());
+		assert!(asset_route.metadata.is_some());
+
+		// Convert back to RouteConfig using TryFrom
+		let back_to_config = RouteConfig::try_from(&asset_route).unwrap();
+		assert_eq!(back_to_config.origin_chain_id, 1);
+		assert_eq!(back_to_config.destination_chain_id, 10);
+		assert_eq!(
+			back_to_config.origin_token_address.to_lowercase(),
+			"0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+		);
+		// Symbols are now preserved in round-trip conversion!
+		assert_eq!(back_to_config.origin_token_symbol, Some("WETH".to_string()));
+		assert_eq!(
+			back_to_config.destination_token_symbol,
+			Some("WETH".to_string())
+		);
+	}
+
+	#[test]
+	fn test_solver_config_with_routes() {
+		let route = RouteConfig::new(
+			1,                                                        // Ethereum
+			"0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0".to_string(), // USDC
+			137,                                                      // Polygon
+			"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174".to_string(), // USDC
+		)
+		.with_origin_symbol("USDC".to_string())
+		.with_destination_symbol("USDC".to_string());
+
+		let config = SolverConfig::new(
+			"test-solver".to_string(),
+			"test-adapter".to_string(),
+			"https://api.example.com".to_string(),
+		)
+		.with_routes(vec![route]);
+
+		// Convert to domain Solver
+		let solver = Solver::try_from(config).unwrap();
+
+		assert_eq!(solver.metadata.supported_routes.len(), 1);
+		assert!(solver.has_route_info());
+
+		let route = &solver.metadata.supported_routes[0];
+		assert_eq!(route.origin_chain_id().unwrap(), 1);
+		assert_eq!(route.destination_chain_id().unwrap(), 137);
+	}
 
 	#[test]
 	fn test_solver_config_validation() {
@@ -287,20 +490,18 @@ mod tests {
 			"https://api.example.com".to_string(),
 		)
 		.with_name("Test Solver".to_string())
-		.with_assets(vec![
-			Asset::new(
-				"0x0000000000000000000000000000000000000000".to_string(),
-				"ETH".to_string(),
-				"Ethereum".to_string(),
-				18,
-				1,
+		.with_routes(vec![
+			RouteConfig::new(
+				1,                                                        // Ethereum
+				"0x0000000000000000000000000000000000000000".to_string(), // ETH
+				137,                                                      // Polygon
+				"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174".to_string(), // USDC
 			),
-			Asset::new(
-				"0x0000000000000000000000000000000000000000".to_string(),
-				"MATIC".to_string(),
-				"Polygon".to_string(),
-				18,
-				137,
+			RouteConfig::new(
+				137,                                                      // Polygon
+				"0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174".to_string(), // USDC
+				1,                                                        // Ethereum
+				"0x0000000000000000000000000000000000000000".to_string(), // ETH
 			),
 		]);
 

--- a/crates/types/src/solvers/mod.rs
+++ b/crates/types/src/solvers/mod.rs
@@ -332,10 +332,10 @@ impl Solver {
 		self.metadata.supported_routes.iter().any(|r| {
 			r.origin_token_symbol
 				.as_ref()
-				.map_or(false, |s| s.eq_ignore_ascii_case(symbol))
+				.is_some_and(|s| s.eq_ignore_ascii_case(symbol))
 				|| r.destination_token_symbol
 					.as_ref()
-					.map_or(false, |s| s.eq_ignore_ascii_case(symbol))
+					.is_some_and(|s| s.eq_ignore_ascii_case(symbol))
 		})
 	}
 

--- a/crates/types/src/solvers/mod.rs
+++ b/crates/types/src/solvers/mod.rs
@@ -106,12 +106,27 @@ pub enum SolverStatus {
 	Initializing,
 }
 
-/// Source of supported assets configuration
+/// 🆕 HYBRID: What assets/routes a solver supports
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub enum SupportedAssets {
+	/// Asset-based: supports any-to-any within asset list (including same-chain)
+	Assets {
+		assets: Vec<Asset>,
+		source: AssetSource,
+	},
+	/// Route-based: supports specific origin->destination pairs
+	Routes {
+		routes: Vec<AssetRoute>,
+		source: AssetSource,
+	},
+}
+
+/// Source of the support data
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum AssetSource {
-	/// Assets are manually defined in configuration
+	/// Data is manually defined in configuration
 	Config,
-	/// Assets are auto-discovered from solver API
+	/// Data is auto-discovered from solver API
 	AutoDiscovered,
 }
 
@@ -127,18 +142,11 @@ pub struct SolverMetadata {
 	/// Version of the solver API
 	pub version: Option<String>,
 
-	/// Supported asset conversion routes (origin -> destination pairs)
-	/// Provides precise compatibility checking for cross-chain operations
-	pub supported_routes: Vec<AssetRoute>,
-
-	/// Source of the supported routes (config vs auto-discovered)
-	pub assets_source: AssetSource,
+	/// What assets/routes this solver supports
+	pub supported_assets: SupportedAssets,
 
 	/// Custom HTTP headers for requests
 	pub headers: Option<HashMap<String, String>>,
-
-	/// Solver-specific configuration
-	pub config: HashMap<String, serde_json::Value>,
 }
 
 /// Performance and health metrics
@@ -321,32 +329,47 @@ impl Solver {
 
 	/// Check if solver supports a specific chain
 	pub fn supports_chain(&self, chain_id: u64) -> bool {
-		self.metadata.supported_routes.iter().any(|r| {
-			r.origin_chain_id().unwrap_or(0) == chain_id
-				|| r.destination_chain_id().unwrap_or(0) == chain_id
-		})
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { assets, .. } => {
+				assets.iter().any(|asset| asset.chain_id == chain_id)
+			},
+			SupportedAssets::Routes { routes, .. } => routes.iter().any(|r| {
+				r.origin_chain_id().unwrap_or(0) == chain_id
+					|| r.destination_chain_id().unwrap_or(0) == chain_id
+			}),
+		}
 	}
 
 	/// Check if solver supports a specific asset by symbol
 	pub fn supports_asset_symbol(&self, symbol: &str) -> bool {
-		self.metadata.supported_routes.iter().any(|r| {
-			r.origin_token_symbol
-				.as_ref()
-				.is_some_and(|s| s.eq_ignore_ascii_case(symbol))
-				|| r.destination_token_symbol
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { assets, .. } => assets
+				.iter()
+				.any(|asset| asset.symbol.eq_ignore_ascii_case(symbol)),
+			SupportedAssets::Routes { routes, .. } => routes.iter().any(|r| {
+				r.origin_token_symbol
 					.as_ref()
 					.is_some_and(|s| s.eq_ignore_ascii_case(symbol))
-		})
+					|| r.destination_token_symbol
+						.as_ref()
+						.is_some_and(|s| s.eq_ignore_ascii_case(symbol))
+			}),
+		}
 	}
 
 	/// Check if solver supports a specific asset on a specific chain
 	pub fn supports_asset_on_chain(&self, chain_id: u64, address: &str) -> bool {
-		self.metadata.supported_routes.iter().any(|r| {
-			(r.origin_chain_id().unwrap_or(0) == chain_id
-				&& r.origin_address().eq_ignore_ascii_case(address))
-				|| (r.destination_chain_id().unwrap_or(0) == chain_id
-					&& r.destination_address().eq_ignore_ascii_case(address))
-		})
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { assets, .. } => assets.iter().any(|asset| {
+				asset.chain_id == chain_id && asset.address.eq_ignore_ascii_case(address)
+			}),
+			SupportedAssets::Routes { routes, .. } => routes.iter().any(|r| {
+				(r.origin_chain_id().unwrap_or(0) == chain_id
+					&& r.origin_address().eq_ignore_ascii_case(address))
+					|| (r.destination_chain_id().unwrap_or(0) == chain_id
+						&& r.destination_address().eq_ignore_ascii_case(address))
+			}),
+		}
 	}
 
 	/// Check if solver supports a specific asset
@@ -356,33 +379,71 @@ impl Solver {
 
 	/// Check if solver supports a specific asset route
 	pub fn supports_route(&self, origin: &InteropAddress, destination: &InteropAddress) -> bool {
-		self.metadata
-			.supported_routes
-			.iter()
-			.any(|route| route.matches(origin, destination))
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { assets, .. } => {
+				// Check if both origin and destination assets are supported
+				let origin_chain_id = match origin.extract_chain_id() {
+					Ok(chain_id) => chain_id,
+					Err(_) => return false,
+				};
+				let dest_chain_id = match destination.extract_chain_id() {
+					Ok(chain_id) => chain_id,
+					Err(_) => return false,
+				};
+
+				let origin_supported = assets.iter().any(|asset| {
+					asset.chain_id == origin_chain_id
+						&& asset.address.eq_ignore_ascii_case(&origin.to_string())
+				});
+				let dest_supported = assets.iter().any(|asset| {
+					asset.chain_id == dest_chain_id
+						&& asset.address.eq_ignore_ascii_case(&destination.to_string())
+				});
+
+				// Both assets must be supported (same-chain is allowed by default now)
+				origin_supported && dest_supported
+			},
+			SupportedAssets::Routes { routes, .. } => routes
+				.iter()
+				.any(|route| route.matches(origin, destination)),
+		}
 	}
 
 	/// Check if solver has route information available
 	pub fn has_route_info(&self) -> bool {
-		!self.metadata.supported_routes.is_empty()
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { assets, .. } => !assets.is_empty(),
+			SupportedAssets::Routes { routes, .. } => !routes.is_empty(),
+		}
 	}
 
 	/// Get all routes for a specific origin asset
 	pub fn routes_from_asset(&self, origin: &InteropAddress) -> Vec<&AssetRoute> {
-		self.metadata
-			.supported_routes
-			.iter()
-			.filter(|route| route.origin_asset == *origin)
-			.collect()
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { .. } => {
+				// For assets mode, we don't have explicit routes
+				// This method is mainly used for routes mode
+				Vec::new()
+			},
+			SupportedAssets::Routes { routes, .. } => routes
+				.iter()
+				.filter(|route| route.origin_asset == *origin)
+				.collect(),
+		}
 	}
 
 	/// Get all routes to a specific destination asset
 	pub fn routes_to_asset(&self, destination: &InteropAddress) -> Vec<&AssetRoute> {
-		self.metadata
-			.supported_routes
-			.iter()
-			.filter(|route| route.destination_asset == *destination)
-			.collect()
+		match &self.metadata.supported_assets {
+			SupportedAssets::Assets { .. } => {
+				// For assets mode, we don't have explicit routes
+				Vec::new()
+			},
+			SupportedAssets::Routes { routes, .. } => routes
+				.iter()
+				.filter(|route| route.destination_asset == *destination)
+				.collect(),
+		}
 	}
 
 	/// Get solver priority score (higher is better)
@@ -426,18 +487,23 @@ impl Solver {
 	}
 
 	pub fn with_routes(mut self, routes: Vec<AssetRoute>) -> Self {
-		self.metadata.supported_routes = routes;
-		// routes_source is now tracked via assets_source
+		self.metadata.supported_assets = SupportedAssets::Routes {
+			routes,
+			source: AssetSource::Config,
+		};
+		self
+	}
+
+	pub fn with_assets(mut self, assets: Vec<Asset>) -> Self {
+		self.metadata.supported_assets = SupportedAssets::Assets {
+			assets,
+			source: AssetSource::Config,
+		};
 		self
 	}
 
 	pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
 		self.metadata.headers = Some(headers);
-		self
-	}
-
-	pub fn with_config(mut self, key: String, value: serde_json::Value) -> Self {
-		self.metadata.config.insert(key, value);
 		self
 	}
 }
@@ -448,10 +514,11 @@ impl Default for SolverMetadata {
 			name: None,
 			description: None,
 			version: None,
-			supported_routes: Vec::new(),
-			assets_source: AssetSource::Config, // Default to config-based until determined
+			supported_assets: SupportedAssets::Routes {
+				routes: Vec::new(),
+				source: AssetSource::AutoDiscovered, // Default to auto-discovery
+			},
 			headers: None,
-			config: HashMap::new(),
 		}
 	}
 }

--- a/crates/types/src/solvers/storage.rs
+++ b/crates/types/src/solvers/storage.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::Asset;
+use crate::AssetRoute;
 
 use super::{
 	AssetSource, HealthCheckResult, Solver, SolverError, SolverMetadata, SolverMetrics,
@@ -38,7 +38,7 @@ pub struct SolverMetadataStorage {
 	pub name: Option<String>,
 	pub description: Option<String>,
 	pub version: Option<String>,
-	pub supported_assets: Vec<Asset>,
+	pub supported_routes: Vec<AssetRoute>,
 	pub assets_source: AssetSource,
 	pub headers: Option<HashMap<String, String>>,
 	pub config: HashMap<String, serde_json::Value>,
@@ -165,7 +165,7 @@ impl From<SolverMetadata> for SolverMetadataStorage {
 			name: metadata.name,
 			description: metadata.description,
 			version: metadata.version,
-			supported_assets: metadata.supported_assets,
+			supported_routes: metadata.supported_routes,
 			assets_source: metadata.assets_source,
 			headers: metadata.headers,
 			config: metadata.config,
@@ -179,7 +179,7 @@ impl From<SolverMetadataStorage> for SolverMetadata {
 			name: storage.name,
 			description: storage.description,
 			version: storage.version,
-			supported_assets: storage.supported_assets,
+			supported_routes: storage.supported_routes,
 			assets_source: storage.assets_source,
 			headers: storage.headers,
 			config: storage.config,

--- a/crates/types/src/solvers/storage.rs
+++ b/crates/types/src/solvers/storage.rs
@@ -4,11 +4,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-use crate::AssetRoute;
-
 use super::{
-	AssetSource, HealthCheckResult, Solver, SolverError, SolverMetadata, SolverMetrics,
-	SolverStatus,
+	HealthCheckResult, Solver, SolverError, SolverMetadata, SolverMetrics, SolverStatus,
+	SupportedAssets,
 };
 
 /// Storage representation of a solver
@@ -38,10 +36,8 @@ pub struct SolverMetadataStorage {
 	pub name: Option<String>,
 	pub description: Option<String>,
 	pub version: Option<String>,
-	pub supported_routes: Vec<AssetRoute>,
-	pub assets_source: AssetSource,
+	pub supported_assets: SupportedAssets,
 	pub headers: Option<HashMap<String, String>>,
-	pub config: HashMap<String, serde_json::Value>,
 }
 
 /// Storage-compatible solver metrics
@@ -165,10 +161,8 @@ impl From<SolverMetadata> for SolverMetadataStorage {
 			name: metadata.name,
 			description: metadata.description,
 			version: metadata.version,
-			supported_routes: metadata.supported_routes,
-			assets_source: metadata.assets_source,
+			supported_assets: metadata.supported_assets,
 			headers: metadata.headers,
-			config: metadata.config,
 		}
 	}
 }
@@ -179,10 +173,8 @@ impl From<SolverMetadataStorage> for SolverMetadata {
 			name: storage.name,
 			description: storage.description,
 			version: storage.version,
-			supported_routes: storage.supported_routes,
-			assets_source: storage.assets_source,
+			supported_assets: storage.supported_assets,
 			headers: storage.headers,
-			config: storage.config,
 		}
 	}
 }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -423,6 +423,69 @@
         },
         "additionalProperties": false
       },
+      "AssetRouteResponse": {
+        "type": "object",
+        "description": "API response format for asset routes with separate chain ID and address fields\n\nThis provides a more readable format for API consumers compared to the\ninternal InteropAddress format used in the domain model.",
+        "required": [
+          "originChainId",
+          "originTokenAddress",
+          "destinationChainId",
+          "destinationTokenAddress"
+        ],
+        "properties": {
+          "destinationChainId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Destination chain ID",
+            "minimum": 0
+          },
+          "destinationTokenAddress": {
+            "type": "string",
+            "description": "Destination token contract address"
+          },
+          "destinationTokenSymbol": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional destination token symbol for readability (e.g., \"WETH\", \"USDC\")"
+          },
+          "metadata": {
+            "description": "Optional route-specific metadata (fees, limits, execution time, etc.)"
+          },
+          "originChainId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Origin chain ID",
+            "minimum": 0
+          },
+          "originTokenAddress": {
+            "type": "string",
+            "description": "Origin token contract address"
+          },
+          "originTokenSymbol": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Optional origin token symbol for readability (e.g., \"WETH\", \"USDC\")"
+          }
+        },
+        "example": {
+          "destinationChainId": 10,
+          "destinationTokenAddress": "0x4200000000000000000000000000000000000006",
+          "destinationTokenSymbol": "WETH",
+          "metadata": {
+            "estimatedFee": "0.001",
+            "estimatedTime": 120,
+            "isNative": false,
+            "source": "across-api"
+          },
+          "originChainId": 1,
+          "originTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+          "originTokenSymbol": "WETH"
+        }
+      },
       "AvailableInput": {
         "type": "object",
         "description": "Available input with lock information and user",
@@ -890,6 +953,9 @@
             "type": "string",
             "description": "HMAC-SHA256 integrity checksum for quote verification\nThis ensures the quote originated from the aggregator service"
           },
+          "metadata": {
+            "description": "Adapter-specific metadata for additional context and execution details\nThis field allows each adapter to include protocol-specific information\nthat consumers might need for order execution or additional context"
+          },
           "orders": {
             "type": "array",
             "items": {
@@ -1232,10 +1298,7 @@
             "$ref": "#/components/schemas/SolverStatus"
           },
           "supportedAssets": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/Asset"
-            }
+            "$ref": "#/components/schemas/SupportedAssetsResponse"
           }
         },
         "additionalProperties": false,
@@ -1248,22 +1311,20 @@
           "name": "Example DeFi Solver",
           "solverId": "example-solver",
           "status": "active",
-          "supportedAssets": [
-            {
-              "address": "0x01000002147a695FbDB2315678afecb367f032d93F642f64180aa3",
-              "chainId": 1,
-              "decimals": 6,
-              "name": "USD Coin",
-              "symbol": "USDC"
-            },
-            {
-              "address": "0x01000002147a69C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-              "chainId": 1,
-              "decimals": 18,
-              "name": "Wrapped Ether",
-              "symbol": "WETH"
-            }
-          ]
+          "supportedAssets": {
+            "routes": [
+              {
+                "destinationChainId": 10,
+                "destinationTokenAddress": "0x4200000000000000000000000000000000000006",
+                "destinationTokenSymbol": "WETH",
+                "originChainId": 1,
+                "originTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                "originTokenSymbol": "WETH"
+              }
+            ],
+            "source": "autoDiscovered",
+            "type": "routes"
+          }
         }
       },
       "SolverSelection": {
@@ -1371,15 +1432,19 @@
               "name": "Example DeFi Solver",
               "solverId": "example-solver",
               "status": "active",
-              "supportedAssets": [
-                {
-                  "address": "0x01000002147a695FbDB2315678afecb367f032d93F642f64180aa3",
-                  "chainId": 1,
-                  "decimals": 6,
-                  "name": "USD Coin",
-                  "symbol": "USDC"
-                }
-              ]
+              "supportedAssets": {
+                "assets": [
+                  {
+                    "address": "0x01000002147a695FbDB2315678afecb367f032d93F642f64180aa3",
+                    "chainId": 1,
+                    "decimals": 6,
+                    "name": "USD Coin",
+                    "symbol": "USDC"
+                  }
+                ],
+                "source": "autoDiscovered",
+                "type": "assets"
+              }
             },
             {
               "adapterId": "uniswap-adapter-v1",
@@ -1390,15 +1455,20 @@
               "name": "Uniswap V3 Solver",
               "solverId": "uniswap-solver",
               "status": "active",
-              "supportedAssets": [
-                {
-                  "address": "0x01000002147a69C02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-                  "chainId": 1,
-                  "decimals": 18,
-                  "name": "Wrapped Ether",
-                  "symbol": "WETH"
-                }
-              ]
+              "supportedAssets": {
+                "routes": [
+                  {
+                    "destinationChainId": 137,
+                    "destinationTokenAddress": "0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619",
+                    "destinationTokenSymbol": "WETH",
+                    "originChainId": 1,
+                    "originTokenAddress": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+                    "originTokenSymbol": "WETH"
+                  }
+                ],
+                "source": "config",
+                "type": "routes"
+              }
             }
           ],
           "totalSolvers": 2
@@ -1423,6 +1493,63 @@
           "backend": "memory",
           "healthy": true
         }
+      },
+      "SupportedAssetsResponse": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "Asset-based: supports any-to-any within asset list (including same-chain)",
+            "required": [
+              "assets",
+              "source",
+              "type"
+            ],
+            "properties": {
+              "assets": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              },
+              "source": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "assets"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Route-based: supports specific origin->destination pairs",
+            "required": [
+              "routes",
+              "source",
+              "type"
+            ],
+            "properties": {
+              "routes": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AssetRouteResponse"
+                }
+              },
+              "source": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "routes"
+                ]
+              }
+            }
+          }
+        ],
+        "description": "Supported assets response format for API"
       },
       "U256": {
         "type": "string",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,7 +142,62 @@ Define external solvers that the aggregator will query:
 
 **Supported Adapters**:
 - `oif-v1` - Standard OIF protocol
+- `across-v1` - Across protocol
 - Custom adapters can be implemented
+
+#### Supported Assets Configuration
+
+Solvers can define their asset support in two modes:
+
+**Assets Mode** - Simple any-to-any within asset list (including same-chain):
+```json
+{
+  "solver_id": "oif-solver",
+  "adapter_id": "oif-v1",
+  "endpoint": "https://api.solver.com",
+  "enabled": true,
+  "supported_assets": {
+    "type": "assets",
+    "assets": [
+      {
+        "chain_id": 1,
+        "address": "0xA0b86a33E6441e3A1Fa1E0c3e1b6f8c5d6f8e9a0",
+        "symbol": "USDC"
+      },
+      {
+        "chain_id": 137,
+        "address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "symbol": "USDC"
+      }
+    ]
+  }
+}
+```
+
+**Routes Mode** - Precise origin→destination pairs:
+```json
+{
+  "solver_id": "across-solver",
+  "adapter_id": "across-v1",
+  "endpoint": "https://api.across.to",
+  "enabled": true,
+  "supported_assets": {
+    "type": "routes",
+    "assets": [
+      {
+        "origin_chain_id": 1,
+        "origin_token_address": "0xA0b86a33E6441e3A1Fa1E0c3e1b6f8c5d6f8e9a0",
+        "origin_token_symbol": "USDC",
+        "destination_chain_id": 137,
+        "destination_token_address": "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
+        "destination_token_symbol": "USDC"
+      }
+    ]
+  }
+}
+```
+
+**Auto-Discovery**: If `supported_assets` is omitted or empty, the aggregator will auto-discover assets/routes from the solver's API.
 
 ### Aggregation Configuration
 

--- a/docs/custom-adapters.md
+++ b/docs/custom-adapters.md
@@ -113,14 +113,6 @@ impl MyCustomAdapter {
 
 #[async_trait]
 impl SolverAdapter for MyCustomAdapter {
-    fn adapter_id(&self) -> &str {
-        &self.adapter_info.adapter_id
-    }
-
-    fn adapter_name(&self) -> &str {
-        &self.adapter_info.name
-    }
-
     fn adapter_info(&self) -> &Adapter {
         &self.adapter_info
     }

--- a/docs/custom-adapters.md
+++ b/docs/custom-adapters.md
@@ -27,7 +27,7 @@ graph LR
     C --> E[submit_order]
     C --> F[health_check]
     C --> G[get_order_details]
-    C --> H[get_supported_routes]
+    C --> H[get_supported_assets]
     
     B --> J[Adapter Registry]
     J --> K[OIF Aggregator]
@@ -154,16 +154,40 @@ impl SolverAdapter for MyCustomAdapter {
         todo!("Implement order details fetching logic")
     }
 
-    async fn get_supported_routes(
+    async fn get_supported_assets(
         &self,
         config: &SolverRuntimeConfig,
-    ) -> AdapterResult<Vec<AssetRoute>> {
-        // 1. Fetch supported routes from solver endpoint
-        // 2. Convert to Vec<AssetRoute> format
-        todo!("Implement routes fetching logic")
+    ) -> AdapterResult<SupportedAssetsData> {
+        // Choose your mode:
+        
+        // Option 1: Assets mode (any-to-any, including same-chain)
+        let assets = vec![/* fetch from API */];
+        Ok(SupportedAssetsData::Assets(assets))
+        
+        // Option 2: Routes mode (precise origin->destination pairs)
+        let routes = vec![/* fetch from API */];
+        Ok(SupportedAssetsData::Routes(routes))
     }
 }
 ```
+
+### 🎯 Choosing Assets vs Routes Mode
+
+**Use Assets Mode When:**
+- ✅ Your solver supports any-to-any conversions within asset list
+- ✅ You want to support same-chain swaps
+- ✅ Route list would be very large (O(N²) explosion)
+- ✅ Example: DEX aggregators, OIF protocol
+
+**Use Routes Mode When:**
+- ✅ Your solver has specific supported routes
+- ✅ Not all asset pairs are supported
+- ✅ You want precise compatibility checking
+- ✅ Example: Bridge protocols, Across protocol
+
+**Auto-Discovery vs Manual Configuration:**
+- **Auto-Discovery**: Omit `supported_assets` - adapter fetches from API
+- **Manual Config**: Define `supported_assets` - use static configuration
 
 ## 📝 Registration and Configuration
 

--- a/docs/custom-adapters.md
+++ b/docs/custom-adapters.md
@@ -28,7 +28,7 @@ graph LR
     C --> F[health_check]
     C --> G[get_order_details]
     C --> H[get_supported_networks]
-    C --> I[get_supported_assets]
+    C --> I[get_supported_routes]
     
     B --> J[Adapter Registry]
     J --> K[OIF Aggregator]
@@ -164,13 +164,13 @@ impl SolverAdapter for MyCustomAdapter {
         todo!("Implement networks fetching logic")
     }
 
-    async fn get_supported_assets(
+    async fn get_supported_routes(
         &self,
         config: &SolverRuntimeConfig,
-    ) -> AdapterResult<Vec<Asset>> {
-        // 1. Fetch supported assets from solver endpoint
-        // 2. Convert to Vec<Asset> format
-        todo!("Implement assets fetching logic")
+    ) -> AdapterResult<Vec<AssetRoute>> {
+        // 1. Fetch supported routes from solver endpoint
+        // 2. Convert to Vec<AssetRoute> format
+        todo!("Implement routes fetching logic")
     }
 }
 ```

--- a/docs/custom-adapters.md
+++ b/docs/custom-adapters.md
@@ -27,8 +27,7 @@ graph LR
     C --> E[submit_order]
     C --> F[health_check]
     C --> G[get_order_details]
-    C --> H[get_supported_networks]
-    C --> I[get_supported_routes]
+    C --> H[get_supported_routes]
     
     B --> J[Adapter Registry]
     J --> K[OIF Aggregator]
@@ -153,15 +152,6 @@ impl SolverAdapter for MyCustomAdapter {
         // 1. Fetch order status from solver endpoint using order_id
         // 2. Convert solver response to GetOrderResponse format
         todo!("Implement order details fetching logic")
-    }
-
-    async fn get_supported_networks(
-        &self,
-        config: &SolverRuntimeConfig,
-    ) -> AdapterResult<Vec<Network>> {
-        // 1. Fetch supported networks from solver endpoint
-        // 2. Convert to Vec<Network> format
-        todo!("Implement networks fetching logic")
     }
 
     async fn get_supported_routes(

--- a/examples/across-example/README.md
+++ b/examples/across-example/README.md
@@ -274,13 +274,13 @@ docker-compose logs oif-aggregator
 **Across solver showing as unhealthy?**
 ```bash
 # Check if Across API is accessible
-curl https://api.across.to/available-routes
+curl https://app.across.to/available-routes
 
 # Verify aggregator logs
 docker-compose logs oif-aggregator | grep across
 
 # Test connectivity from container
-docker-compose exec oif-aggregator curl https://api.across.to/available-routes
+docker-compose exec oif-aggregator curl https://app.across.to/available-routes
 ```
 
 **Getting "UnsupportedOperation" for orders?**

--- a/examples/across-example/README.md
+++ b/examples/across-example/README.md
@@ -26,7 +26,7 @@ The example includes both mainnet and testnet Across solvers:
 ```json
 {
   "server": { "host": "0.0.0.0", "port": 4000 },
-  "solvers": "solvers": {
+  "solvers": {
     "across-solver-testnet": {
       "solver_id": "across-solver-testnet",
       "adapter_id": "across-v1",

--- a/examples/across-example/README.md
+++ b/examples/across-example/README.md
@@ -1,0 +1,311 @@
+# Across Solver Tutorial
+
+This tutorial walks you through setting up and running the OIF Aggregator with Across Protocol integration.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+
+## Step 1: Start the OIF Aggregator
+
+The docker-compose.yml will build and start the aggregator automatically:
+
+```bash
+# From this directory
+docker-compose up -d
+```
+
+## Step 2: Understanding the Across Configuration
+
+This example demonstrates how to configure the OIF Aggregator to work with Across Protocol solvers.
+
+### Configuration Structure
+
+The example includes both mainnet and testnet Across solvers:
+
+```json
+{
+  "server": { "host": "0.0.0.0", "port": 4000 },
+  "solvers": "solvers": {
+    "across-solver-testnet": {
+      "solver_id": "across-solver-testnet",
+      "adapter_id": "across-v1",
+      "endpoint": "https://testnet.across.to/api",
+      "timeout_ms": 2000,
+      "enabled": true,
+      "max_retries": 1,
+      "headers": null,
+      "name": "Across Solver Testnet",
+      "description": "Across Solver Testnet"
+    },
+    "across-solver-mainnet": {
+      "solver_id": "across-solver-mainnet",
+      "adapter_id": "across-v1",
+      "endpoint": "https://app.across.to/api",
+      "timeout_ms": 3000,
+      "enabled": true,
+      "max_retries": 1,
+      "headers": null,
+      "name": "Across Solver Mainnet",
+      "description": "Across Solver Mainnet"
+    }
+  },
+  "aggregation": {
+    "global_timeout_ms": 5000,
+    "per_solver_timeout_ms": 3000,
+    "max_concurrent_solvers": 50
+  }
+}
+```
+
+### Key Configuration Fields
+
+- **`adapter_id`**: Must be `"across-v1"` to use the Across adapter
+- **`endpoint`**: Across API endpoints (mainnet: `https://app.across.to/api`, testnet: `https://testnet.across.to/api`)
+- **`solver_id`**: Unique identifier for each solver instance
+- **Auto-Discovery**: Routes are automatically discovered from Across `/available-routes` endpoint
+- **Timeout Configuration**: Per-solver and global timeout settings
+
+### How Across Integration Works
+
+1. **Route Discovery**: On startup, the aggregator fetches available routes from Across API
+2. **Quote Requests**: When quotes are requested, the aggregator calls Across `/suggested-fees` endpoint
+3. **Health Monitoring**: Background jobs monitor Across API health via `/available-routes`
+4. **Metadata Enrichment**: Responses include detailed Across-specific data like relay fees and fill times
+
+### Environment Variables
+
+The `docker-compose.yml` demonstrates environment variable overrides:
+
+```yaml
+environment:
+  - HOST=0.0.0.0              # Server binding
+  - PORT=4000                 # Server port
+  - RUST_LOG=info             # Log level
+  - INTEGRITY_SECRET=example-secret
+```
+
+## Step 3: Verify the Service is Running
+
+Check that the aggregator started successfully:
+
+```bash
+# View startup logs
+docker-compose logs -f
+
+# In another terminal, check health
+curl http://localhost:4000/health
+```
+
+**What the startup does:**
+- 🏗️ Builds the OIF Aggregator from source
+- 🚀 Starts OIF Aggregator on port 4000
+- 📁 Mounts custom Across configuration
+- 🔗 Connects to Across Protocol API for route discovery
+
+## Step 4: Explore the Across Integration
+
+The aggregator is now running with Across Protocol integration:
+
+```bash
+# Check aggregator health
+curl http://localhost:4000/health
+
+# Get available solvers (should show Across solver with auto-discovered routes)
+curl http://localhost:4000/v1/solvers
+
+# Request quotes for cross-chain transfers
+curl -X POST http://localhost:4000/v1/quotes \
+  -H "Content-Type: application/json" \
+  -d '{
+  "user": "0x0100000314aa37dc742d35cc6634c0532925a3b8d38ba2297c33a9d7",
+  "availableInputs": [
+    {
+      "user": "0x0100000314aa37dc742d35cc6634c0532925a3b8d38ba2297c33a9d7",
+      "asset": "0x0100000314aa37dc4200000000000000000000000000000000000006",
+      "amount": "100000000000000"
+    }
+  ],
+  "requestedOutputs": [
+    {
+      "receiver": "0x010000031401f977742d35cc6634c0532925a3b8d38ba2297c33a9d7",
+      "asset": "0x010000031401f97717b8ee96e3bcb3b04b3e8334de4524520c51cab4",
+      "amount": "100000000000000"
+    }
+  ],
+  "minValidUntil": 300,
+  "preference": null,
+  "solverOptions": {
+      "timeout": 6000
+  }
+}'
+```
+
+**Expected responses:**
+- Health check: Status with Across solver health information
+- Solvers: Across solver with auto-discovered supported routes
+- Quotes: Real quotes from Across Protocol for supported routes
+
+## Step 5: Understanding Across Protocol Integration
+
+At this point, you have:
+- ✅ **OIF Aggregator running** on port 4000
+- ✅ **Across Protocol connected** with real-time route discovery
+- ✅ **Live quotes available** for supported cross-chain routes
+- ⚠️ **Order operations not implemented** (see limitations below)
+
+### API Structure
+The aggregator exposes these endpoints:
+```bash
+GET  /health                 # Service health
+GET  /v1/solvers            # Available solvers (shows Across with routes)
+POST /v1/quotes             # Request quotes (✅ Fully functional)
+POST /v1/orders/{id}        # Get order details (❌ Not implemented)
+POST /v1/orders             # Create orders (❌ Not implemented)
+```
+
+### 🚨 Current Limitations
+
+**Order Operations Not Supported:**
+- `POST /v1/orders` (submit order) - Returns "UnsupportedOperation"
+- `GET /v1/orders/{id}` (order details) - Returns "UnsupportedOperation"
+
+**Why Order Operations Aren't Implemented:**
+1. **Frontend Integration**: Order submission will be handled by frontend applications
+2. **User Control**: Users maintain full control over their transactions
+
+**What IS Supported:**
+- ✅ **Quote Requests**: Get real quotes from Across Protocol
+- ✅ **Route Discovery**: Automatic discovery of supported asset routes  
+- ✅ **Health Monitoring**: Real-time Across API health checks
+- ✅ **Rich Metadata**: Detailed quote information including fees and timing
+- ✅ **Multi-Chain Support**: Ethereum, Optimism, Polygon, Arbitrum, Base, and more
+- ✅ **Real-Time Pricing**: Live fee calculations from Across Protocol
+
+### Custom Headers and Timeouts
+
+```json
+{
+  "solvers": {
+    "across-solver-mainnet": {
+      "solver_id": "across-solver-mainnet",
+      "adapter_id": "across-v1",
+      "endpoint": "https://app.across.to/api",
+      "timeout_ms": 3000,
+      "max_retries": 2,
+      "enabled": true,
+      "headers": {
+        "X-API-Key": "your-api-key",
+        "User-Agent": "OIF-Aggregator/1.0"
+      }
+    }
+  },
+  "aggregation": {
+    "global_timeout_ms": 10000,
+    "per_solver_timeout_ms": 4000,
+    "max_concurrent_solvers": 5
+  }
+}
+```
+
+### Environment Overrides
+
+Change `docker-compose.yml` environment variables:
+```yaml
+environment:
+  - RUST_LOG=debug           # More verbose logging
+  - PORT=8080               # Different port
+  - HOST=127.0.0.1          # Local only binding
+```
+
+## Step 7: Frontend Integration Planning
+
+### Order Submission Flow
+
+Since order operations are not implemented in the aggregator, frontend applications should:
+
+1. **Get Quotes**: Use the aggregator's `/v1/quotes` endpoint
+2. **Direct Integration**: Implement Across Protocol SDK directly in frontend
+3. **User Signing**: Handle transaction signing in the user's wallet
+4. **Status Tracking**: Monitor transaction status via Across APIs
+
+### Future Frontend Support
+
+Order operations will be supported through frontend applications in the near future:
+- **Frontend SDKs**: Direct integration with Across Protocol
+- **Wallet Integration**: Seamless transaction signing
+- **Status Monitoring**: Real-time order tracking
+- **User Experience**: Streamlined cross-chain transfers
+
+## Step 8: Clean Up
+
+Stop and remove everything:
+
+```bash
+# Stop services
+docker-compose down
+
+# Remove everything including volumes
+docker-compose down -v
+```
+
+## Next Steps
+
+🚀 **Ready for more?**
+- Connect additional solver protocols
+- Explore the [API documentation](../../docs/)
+- Set up monitoring and logging
+- Build frontend integration with Across SDK
+
+## Troubleshooting
+
+**Aggregator won't start?**
+```bash
+# Check logs
+docker-compose logs oif-aggregator
+
+# Common issues:
+# - INTEGRITY_SECRET not set
+# - Port 4000 already in use
+# - Config file syntax errors
+# - Invalid Across endpoint
+```
+
+**Across solver showing as unhealthy?**
+```bash
+# Check if Across API is accessible
+curl https://api.across.to/available-routes
+
+# Verify aggregator logs
+docker-compose logs oif-aggregator | grep across
+
+# Test connectivity from container
+docker-compose exec oif-aggregator curl https://api.across.to/available-routes
+```
+
+**Getting "UnsupportedOperation" for orders?**
+```bash
+# This is expected behavior - order operations are not implemented
+# Use the quotes endpoint instead:
+curl -X POST http://localhost:4000/v1/quotes -H "Content-Type: application/json" -d '...'
+```
+
+**Need debug logs?**
+```bash
+# Stop and restart with debug logging
+docker-compose down
+# Edit docker-compose.yml: RUST_LOG=debug
+docker-compose up -d
+```
+
+**Want to test different routes?**
+```bash
+# Check available routes first
+curl http://localhost:4000/v1/solvers
+
+# Then test with supported asset pairs from the routes list
+```
+
+---
+
+**🎉 Congratulations!** You've successfully set up the OIF Aggregator with Across Protocol integration. The aggregator can now provide real quotes for cross-chain transfers, with order execution to be handled by frontend applications.

--- a/examples/across-example/config.json
+++ b/examples/across-example/config.json
@@ -1,0 +1,55 @@
+{
+  "server": {
+    "host": "0.0.0.0",
+    "port": 4000
+  },
+  "solvers": {
+    "across-solver-testnet": {
+      "solver_id": "across-solver-testnet",
+      "adapter_id": "across-v1",
+      "endpoint": "https://testnet.across.to/api",
+      "timeout_ms": 2000,
+      "enabled": true,
+      "max_retries": 1,
+      "headers": null,
+      "name": "Across Solver Testnet",
+      "description": "Across Solver Testnet"
+    },
+    "across-solver-mainnet": {
+      "solver_id": "across-solver-mainnet",
+      "adapter_id": "across-v1",
+      "endpoint": "https://app.across.to/api",
+      "timeout_ms": 2000,
+      "enabled": true,
+      "max_retries": 1,
+      "headers": null,
+      "name": "Across Solver Mainnet",
+      "description": "Across Solver Mainnet"
+    }
+  },
+  "aggregation": {
+    "global_timeout_ms": 5000,
+    "per_solver_timeout_ms": 3000,
+    "max_concurrent_solvers": 10,
+    "max_retries_per_solver": 2,
+    "retry_delay_ms": 100
+  },
+  "environment": {
+    "rate_limiting": {
+      "enabled": true,
+      "requests_per_minute": 60,
+      "burst_size": 10
+    }
+  },
+  "logging": {
+    "level": "info",
+    "format": "pretty",
+    "structured": false
+  },
+  "security": {
+    "integrity_secret": {
+      "type": "env",
+      "value": "INTEGRITY_SECRET"
+    }
+  }
+}

--- a/examples/across-example/docker-compose.yaml
+++ b/examples/across-example/docker-compose.yaml
@@ -1,0 +1,29 @@
+services:
+  # OIF Aggregator service
+  oif-aggregator:
+    build:
+      context: ../../
+      dockerfile: Dockerfile
+    ports:
+      - "4000:4000"
+    volumes:
+      # Mount our custom config file
+      - ./config.json:/app/config/config.json:ro
+    environment:
+      # Environment variables (override config file values)
+      - HOST=0.0.0.0
+      - PORT=4000
+      - RUST_LOG=info
+      - INTEGRITY_SECRET=example-secret-key-change-in-production
+    networks:
+      - oif-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+networks:
+  oif-network:
+    driver: bridge

--- a/examples/builder_demo.rs
+++ b/examples/builder_demo.rs
@@ -18,11 +18,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	// Demo 1: Minimal builder with default adapters only
 	println!("\n1. 📦 Minimal Builder (Default Adapters Only)");
-	println!("   Creating aggregator with OIF and LiFi adapters...");
+	println!("   Creating aggregator with OIF, LiFi and Across adapters...");
 
 	let (_app1, _state1) = AggregatorBuilder::default().start().await?;
 
-	println!("   ✅ Built aggregator with default adapters (OIF + LiFi)");
+	println!("   ✅ Built aggregator with default adapters (OIF + LiFi + Across)");
 
 	// Demo 2: Builder with custom mock adapter
 	println!("\n2. 🔧 Builder with Custom Mock Adapter");
@@ -131,7 +131,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 	println!("\n6. 📊 Builder Pattern Summary");
 	println!("   The AggregatorBuilder provides:");
-	println!("   🔸 AggregatorBuilder::default() - Start with OIF/LiFi defaults");
+	println!("   🔸 AggregatorBuilder::default() - Start with OIF/LiFi/Across defaults");
 	println!("   🔸 .with_adapter(adapter) - Add custom adapter implementations");
 	println!("   🔸 .with_solver(solver) - Register solvers for adapters");
 	println!("   🔸 .start() - Build the router and application state");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use oif_service::{
 	IntegrityTrait, JobProcessor, JobProcessorConfig, SolverFilterService, SolverFilterTrait,
 	SolverService, SolverServiceTrait,
 };
-use oif_types::solvers::AssetSource;
 
 // Core domain types - the most commonly used types
 pub use oif_types::{
@@ -227,13 +226,8 @@ where
 		let mut solver =
 			Solver::try_from(domain_config).expect("Failed to convert valid config to solver");
 
-		// Set runtime status and discovery source
+		// Set runtime status (source is already set in the conversion)
 		solver.status = SolverStatus::Active;
-		solver.metadata.assets_source = if solver.metadata.supported_routes.is_empty() {
-			AssetSource::AutoDiscovered
-		} else {
-			AssetSource::Config
-		};
 
 		solver
 	}

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -57,14 +57,6 @@ impl Default for MockDemoAdapter {
 
 #[async_trait]
 impl SolverAdapter for MockDemoAdapter {
-	fn adapter_id(&self) -> &str {
-		&self.id
-	}
-
-	fn adapter_name(&self) -> &str {
-		&self.name
-	}
-
 	fn adapter_info(&self) -> &oif_types::Adapter {
 		&self.adapter
 	}
@@ -137,6 +129,7 @@ impl SolverAdapter for MockDemoAdapter {
 			valid_until: Some(Utc::now().timestamp() as u64 + 300),
 			eta: Some(30),
 			provider: format!("{} Provider", self.name),
+			metadata: None,
 		};
 
 		Ok(GetQuoteResponse {
@@ -260,13 +253,23 @@ pub struct MockTestAdapter {
 	pub id: String,
 	pub name: String,
 	pub should_fail: bool,
+	pub adapter_info: oif_types::Adapter,
 }
 
 impl MockTestAdapter {
 	pub fn new() -> Self {
+		let id = "mock-test-v1".to_string();
+		let name = "Mock Test Adapter".to_string();
+
 		Self {
-			id: "mock-test-v1".to_string(),
-			name: "Mock Test Adapter".to_string(),
+			adapter_info: oif_types::Adapter::new(
+				id.clone(),
+				"Mock Test Adapter for testing".to_string(),
+				name.clone(),
+				"1.0.0".to_string(),
+			),
+			id,
+			name,
 			should_fail: false,
 		}
 	}
@@ -280,16 +283,8 @@ impl Default for MockTestAdapter {
 
 #[async_trait]
 impl SolverAdapter for MockTestAdapter {
-	fn adapter_id(&self) -> &str {
-		&self.id
-	}
-
-	fn adapter_name(&self) -> &str {
-		&self.name
-	}
-
 	fn adapter_info(&self) -> &oif_types::Adapter {
-		todo!("Mock adapters don't need full adapter info")
+		&self.adapter_info
 	}
 
 	async fn get_quotes(

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -20,7 +20,7 @@ use oif_types::adapters::{
 };
 use oif_types::serde_json::{json, Value};
 use oif_types::Solver;
-use oif_types::{models::AssetRoute, models::Network, InteropAddress, SolverRuntimeConfig, U256};
+use oif_types::{models::AssetRoute, InteropAddress, SolverRuntimeConfig, U256};
 
 /// Simple mock adapter for examples and testing
 #[derive(Debug, Clone)]
@@ -245,16 +245,6 @@ impl SolverAdapter for MockDemoAdapter {
 	async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> {
 		Ok(true)
 	}
-
-	async fn get_supported_networks(
-		&self,
-		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Network>> {
-		Ok(vec![
-			Network::new(1, Some("Ethereum".to_string()), Some(false)),
-			Network::new(137, Some("Polygon".to_string()), Some(false)),
-		])
-	}
 }
 
 /// Simple test adapter that can be configured to succeed or fail
@@ -409,20 +399,6 @@ impl SolverAdapter for MockTestAdapter {
 
 	async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> {
 		Ok(!self.should_fail)
-	}
-
-	async fn get_supported_networks(
-		&self,
-		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Network>> {
-		if self.should_fail {
-			return Err(oif_types::AdapterError::from(
-				AdapterValidationError::InvalidConfiguration {
-					reason: "Mock adapter configured to fail".to_string(),
-				},
-			));
-		}
-		Ok(vec![])
 	}
 }
 

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -20,7 +20,7 @@ use oif_types::adapters::{
 };
 use oif_types::serde_json::{json, Value};
 use oif_types::Solver;
-use oif_types::{models::Asset, models::Network, InteropAddress, SolverRuntimeConfig, U256};
+use oif_types::{models::AssetRoute, models::Network, InteropAddress, SolverRuntimeConfig, U256};
 
 /// Simple mock adapter for examples and testing
 #[derive(Debug, Clone)]
@@ -210,24 +210,34 @@ impl SolverAdapter for MockDemoAdapter {
 		})
 	}
 
-	async fn get_supported_assets(
+	async fn get_supported_routes(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Asset>> {
+	) -> AdapterResult<Vec<AssetRoute>> {
+		// Mock cross-chain routes for testing
+		use oif_types::models::InteropAddress;
+
+		let eth_mainnet =
+			InteropAddress::from_chain_and_address(1, "0x0000000000000000000000000000000000000000")
+				.unwrap();
+		let usdc_optimism = InteropAddress::from_chain_and_address(
+			10,
+			"0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+		)
+		.unwrap();
+
 		Ok(vec![
-			Asset::new(
-				"0x0000000000000000000000000000000000000000".to_string(),
+			AssetRoute::with_symbols(
+				eth_mainnet.clone(),
 				"ETH".to_string(),
-				"Ethereum".to_string(),
-				18,
-				1,
-			),
-			Asset::new(
-				"0xa0b86a33e6417a77c9a0c65f8e69b8b6e2b0c4a0".to_string(),
+				usdc_optimism.clone(),
 				"USDC".to_string(),
-				"USD Coin".to_string(),
-				6,
-				1,
+			),
+			AssetRoute::with_symbols(
+				usdc_optimism,
+				"USDC".to_string(),
+				eth_mainnet,
+				"ETH".to_string(),
 			),
 		])
 	}
@@ -383,10 +393,10 @@ impl SolverAdapter for MockTestAdapter {
 		})
 	}
 
-	async fn get_supported_assets(
+	async fn get_supported_routes(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Asset>> {
+	) -> AdapterResult<Vec<AssetRoute>> {
 		if self.should_fail {
 			return Err(oif_types::AdapterError::from(
 				AdapterValidationError::InvalidConfiguration {

--- a/src/mocks.rs
+++ b/src/mocks.rs
@@ -6,17 +6,17 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use oif_types::adapters::models::{SolMandateOutput, StandardOrder};
 use oif_types::chrono::Utc;
 
 use oif_types::adapters::{
 	models::{
 		AdapterQuote, AssetAmount, AvailableInput, GetOrderResponse, GetQuoteRequest,
 		GetQuoteResponse, OrderResponse, OrderStatus, QuoteDetails, QuoteOrder, RequestedOutput,
-		Settlement, SettlementType, SignatureType, SubmitOrderRequest, SubmitOrderResponse,
+		Settlement, SettlementType, SignatureType, SolMandateOutput, StandardOrder,
+		SubmitOrderRequest, SubmitOrderResponse,
 	},
 	traits::SolverAdapter,
-	AdapterResult, AdapterValidationError, SupportedAssetsData,
+	AdapterError, AdapterResult, AdapterValidationError, SupportedAssetsData,
 };
 use oif_types::serde_json::{json, Value};
 use oif_types::Solver;
@@ -218,29 +218,38 @@ impl SolverAdapter for MockDemoAdapter {
 		// Support assets that match the test fixtures
 		let assets = vec![
 			// Native ETH on Ethereum
-			Asset::new(
+			Asset::from_chain_and_address(
+				1,
 				"0x0000000000000000000000000000000000000000".to_string(),
 				"ETH".to_string(),
 				"Ethereum".to_string(),
 				18,
-				1,
-			),
+			)
+			.map_err(|e| AdapterError::InvalidResponse {
+				reason: format!("Invalid mock asset: {}", e),
+			})?,
 			// WETH on Ethereum (matches test fixtures)
-			Asset::new(
+			Asset::from_chain_and_address(
+				1,
 				"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
 				"WETH".to_string(),
 				"Wrapped Ethereum".to_string(),
 				18,
-				1,
-			),
+			)
+			.map_err(|e| AdapterError::InvalidResponse {
+				reason: format!("Invalid mock asset: {}", e),
+			})?,
 			// USDC on Ethereum (matches test fixtures)
-			Asset::new(
+			Asset::from_chain_and_address(
+				1,
 				"0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0".to_string(),
 				"USDC".to_string(),
 				"USD Coin".to_string(),
 				6,
-				1,
-			),
+			)
+			.map_err(|e| AdapterError::InvalidResponse {
+				reason: format!("Invalid mock asset: {}", e),
+			})?,
 		];
 
 		Ok(SupportedAssetsData::Assets(assets))
@@ -413,29 +422,32 @@ pub fn mock_solver() -> Solver {
 	// Create assets that match the test fixtures for immediate compatibility
 	let assets = vec![
 		// Native ETH on Ethereum
-		Asset::new(
+		Asset::from_chain_and_address(
+			1,
 			"0x0000000000000000000000000000000000000000".to_string(),
 			"ETH".to_string(),
 			"Ethereum".to_string(),
 			18,
-			1,
-		),
+		)
+		.expect("Valid ETH asset"),
 		// WETH on Ethereum (matches test fixtures)
-		Asset::new(
+		Asset::from_chain_and_address(
+			1,
 			"0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2".to_string(),
 			"WETH".to_string(),
 			"Wrapped Ethereum".to_string(),
 			18,
-			1,
-		),
+		)
+		.expect("Valid WETH asset"),
 		// USDC on Ethereum (matches test fixtures)
-		Asset::new(
+		Asset::from_chain_and_address(
+			1,
 			"0xA0b86a33E6417a77C9A0C65f8E69b8b6e2b0c4A0".to_string(),
 			"USDC".to_string(),
 			"USD Coin".to_string(),
 			6,
-			1,
-		),
+		)
+		.expect("Valid USDC asset"),
 	];
 
 	Solver::new(

--- a/tests/adapter_test.rs
+++ b/tests/adapter_test.rs
@@ -81,8 +81,17 @@ async fn test_aggregation_service_creation() {
 		"test-secret",
 	)));
 
+	// Create storage and populate with solvers
+	let storage = Arc::new(oif_storage::MemoryStore::new()) as Arc<dyn oif_storage::Storage>;
+	for solver in solvers {
+		storage
+			.create_solver(solver)
+			.await
+			.expect("Failed to create test solver");
+	}
+
 	let service = AggregatorService::new(
-		solvers,
+		storage,
 		adapter_registry,
 		integrity_service,
 		Arc::new(oif_service::SolverFilterService::new())

--- a/tests/adapter_test.rs
+++ b/tests/adapter_test.rs
@@ -16,14 +16,14 @@ use crate::mocks::api_fixtures::INTEGRITY_SECRET;
 #[test]
 fn test_adapter_registry_creation() {
 	let registry = AdapterRegistry::new();
-	// Registry starts with default adapters (OIF and LiFi)
+	// Registry starts with default adapters (OIF, LiFi, Across)
 	assert!(registry.get_all().is_empty());
 }
 
 #[test]
 fn test_adapter_registry_with_defaults() {
 	let registry = AdapterRegistry::with_defaults();
-	// Should have default OIF and LiFi adapters
+	// Should have default OIF, LiFi and Across adapters
 	assert!(registry.get_all().len() >= 2);
 }
 

--- a/tests/mocks/adapters.rs
+++ b/tests/mocks/adapters.rs
@@ -23,7 +23,7 @@ use oif_types::adapters::{
 	AdapterResult, AdapterValidationError,
 };
 use oif_types::serde_json::json;
-use oif_types::{models::Asset, models::Network, InteropAddress, SolverRuntimeConfig, U256};
+use oif_types::{models::AssetRoute, models::Network, InteropAddress, SolverRuntimeConfig, U256};
 
 /// Simple mock adapter for examples and testing
 #[derive(Debug, Clone)]
@@ -221,24 +221,34 @@ impl SolverAdapter for MockDemoAdapter {
 		})
 	}
 
-	async fn get_supported_assets(
+	async fn get_supported_routes(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Asset>> {
+	) -> AdapterResult<Vec<AssetRoute>> {
+		// Mock cross-chain routes for testing
+		use oif_types::models::InteropAddress;
+
+		let eth_mainnet =
+			InteropAddress::from_chain_and_address(1, "0x0000000000000000000000000000000000000000")
+				.unwrap();
+		let usdc_optimism = InteropAddress::from_chain_and_address(
+			10,
+			"0x7F5c764cBc14f9669B88837ca1490cCa17c31607",
+		)
+		.unwrap();
+
 		Ok(vec![
-			Asset::new(
-				"0x0000000000000000000000000000000000000000".to_string(),
+			AssetRoute::with_symbols(
+				eth_mainnet.clone(),
 				"ETH".to_string(),
-				"Ethereum".to_string(),
-				18,
-				1,
-			),
-			Asset::new(
-				"0xa0b86a33e6417a77c9a0c65f8e69b8b6e2b0c4a0".to_string(),
+				usdc_optimism.clone(),
 				"USDC".to_string(),
-				"USD Coin".to_string(),
-				6,
-				1,
+			),
+			AssetRoute::with_symbols(
+				usdc_optimism,
+				"USDC".to_string(),
+				eth_mainnet,
+				"ETH".to_string(),
 			),
 		])
 	}
@@ -410,10 +420,10 @@ impl SolverAdapter for MockTestAdapter {
 		})
 	}
 
-	async fn get_supported_assets(
+	async fn get_supported_routes(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Asset>> {
+	) -> AdapterResult<Vec<AssetRoute>> {
 		if self.should_fail {
 			return Err(oif_types::AdapterError::from(
 				AdapterValidationError::InvalidConfiguration {
@@ -751,10 +761,10 @@ impl SolverAdapter for TimingControlledAdapter {
 		}])
 	}
 
-	async fn get_supported_assets(
+	async fn get_supported_routes(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<oif_types::models::Asset>> {
+	) -> AdapterResult<Vec<AssetRoute>> {
 		Ok(vec![])
 	}
 }

--- a/tests/mocks/adapters.rs
+++ b/tests/mocks/adapters.rs
@@ -23,7 +23,7 @@ use oif_types::adapters::{
 	AdapterResult, AdapterValidationError,
 };
 use oif_types::serde_json::json;
-use oif_types::{models::AssetRoute, models::Network, InteropAddress, SolverRuntimeConfig, U256};
+use oif_types::{models::AssetRoute, InteropAddress, SolverRuntimeConfig, U256};
 
 /// Simple mock adapter for examples and testing
 #[derive(Debug, Clone)]
@@ -256,16 +256,6 @@ impl SolverAdapter for MockDemoAdapter {
 	async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> {
 		Ok(true)
 	}
-
-	async fn get_supported_networks(
-		&self,
-		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Network>> {
-		Ok(vec![
-			Network::new(1, Some("Ethereum".to_string()), Some(false)),
-			Network::new(137, Some("Polygon".to_string()), Some(false)),
-		])
-	}
 }
 
 /// Simple test adapter that can be configured to succeed or fail
@@ -436,20 +426,6 @@ impl SolverAdapter for MockTestAdapter {
 
 	async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> {
 		Ok(!self.should_fail)
-	}
-
-	async fn get_supported_networks(
-		&self,
-		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<Network>> {
-		if self.should_fail {
-			return Err(oif_types::AdapterError::from(
-				AdapterValidationError::InvalidConfiguration {
-					reason: "Mock adapter configured to fail".to_string(),
-				},
-			));
-		}
-		Ok(vec![])
 	}
 }
 
@@ -748,17 +724,6 @@ impl SolverAdapter for TimingControlledAdapter {
 		}
 
 		Ok(true)
-	}
-
-	async fn get_supported_networks(
-		&self,
-		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<oif_types::models::Network>> {
-		Ok(vec![oif_types::models::Network {
-			chain_id: 1,
-			name: Some("Ethereum Mainnet".to_string()),
-			is_testnet: Some(false),
-		}])
 	}
 
 	async fn get_supported_routes(

--- a/tests/mocks/adapters.rs
+++ b/tests/mocks/adapters.rs
@@ -221,10 +221,10 @@ impl SolverAdapter for MockDemoAdapter {
 		})
 	}
 
-	async fn get_supported_routes(
+	async fn get_supported_assets(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<AssetRoute>> {
+	) -> AdapterResult<oif_types::adapters::SupportedAssetsData> {
 		// Mock cross-chain routes for testing
 		use oif_types::models::InteropAddress;
 
@@ -237,7 +237,7 @@ impl SolverAdapter for MockDemoAdapter {
 		)
 		.unwrap();
 
-		Ok(vec![
+		Ok(oif_types::adapters::SupportedAssetsData::Routes(vec![
 			AssetRoute::with_symbols(
 				eth_mainnet.clone(),
 				"ETH".to_string(),
@@ -250,7 +250,7 @@ impl SolverAdapter for MockDemoAdapter {
 				eth_mainnet,
 				"ETH".to_string(),
 			),
-		])
+		]))
 	}
 
 	async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> {
@@ -410,10 +410,10 @@ impl SolverAdapter for MockTestAdapter {
 		})
 	}
 
-	async fn get_supported_routes(
+	async fn get_supported_assets(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<AssetRoute>> {
+	) -> AdapterResult<oif_types::adapters::SupportedAssetsData> {
 		if self.should_fail {
 			return Err(oif_types::AdapterError::from(
 				AdapterValidationError::InvalidConfiguration {
@@ -421,7 +421,7 @@ impl SolverAdapter for MockTestAdapter {
 				},
 			));
 		}
-		Ok(vec![])
+		Ok(oif_types::adapters::SupportedAssetsData::Routes(vec![]))
 	}
 
 	async fn health_check(&self, _config: &SolverRuntimeConfig) -> AdapterResult<bool> {
@@ -726,10 +726,10 @@ impl SolverAdapter for TimingControlledAdapter {
 		Ok(true)
 	}
 
-	async fn get_supported_routes(
+	async fn get_supported_assets(
 		&self,
 		_config: &SolverRuntimeConfig,
-	) -> AdapterResult<Vec<AssetRoute>> {
-		Ok(vec![])
+	) -> AdapterResult<oif_types::adapters::SupportedAssetsData> {
+		Ok(oif_types::adapters::SupportedAssetsData::Routes(vec![]))
 	}
 }

--- a/tests/mocks/configs.rs
+++ b/tests/mocks/configs.rs
@@ -72,13 +72,8 @@ impl MockConfigs {
 			description: Some("Test solver for unit testing".to_string()),
 			endpoint: "http://localhost:8080".to_string(),
 			headers: Some(HashMap::new()),
-			supported_assets: Some(vec![AssetConfig {
-				address: "0x0000000000000000000000000000000000000000".to_string(),
-				symbol: "ETH".to_string(),
-				name: "Ethereum".to_string(),
-				decimals: 18,
-				chain_id: 1,
-			}]),
+
+			supported_routes: None,
 			enabled: true,
 		}
 	}
@@ -106,13 +101,8 @@ impl SolverConfigBuilder {
 				description: Some("Test solver".to_string()),
 				endpoint: "http://localhost:8080".to_string(),
 				headers: Some(HashMap::new()),
-				supported_assets: Some(vec![AssetConfig {
-					address: "0x0000000000000000000000000000000000000000".to_string(),
-					symbol: "ETH".to_string(),
-					name: "Ethereum".to_string(),
-					decimals: 18,
-					chain_id: 1,
-				}]),
+
+				supported_routes: None,
 				enabled: true,
 			},
 		}

--- a/tests/mocks/configs.rs
+++ b/tests/mocks/configs.rs
@@ -72,8 +72,7 @@ impl MockConfigs {
 			description: Some("Test solver for unit testing".to_string()),
 			endpoint: "http://localhost:8080".to_string(),
 			headers: Some(HashMap::new()),
-
-			supported_routes: None,
+			supported_assets: None,
 			enabled: true,
 		}
 	}
@@ -102,7 +101,7 @@ impl SolverConfigBuilder {
 				endpoint: "http://localhost:8080".to_string(),
 				headers: Some(HashMap::new()),
 
-				supported_routes: None,
+				supported_assets: None,
 				enabled: true,
 			},
 		}

--- a/tests/solver_options_e2e.rs
+++ b/tests/solver_options_e2e.rs
@@ -1032,8 +1032,14 @@ async fn test_solver_inclusion_filtering_behavior() {
 	let client = Client::new();
 
 	// Find our adapters by their IDs
-	let fast_adapter = adapters.iter().find(|a| a.id == "timing-fast").unwrap();
-	let slow_adapter = adapters.iter().find(|a| a.id == "timing-slow").unwrap();
+	let fast_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-fast")
+		.unwrap();
+	let slow_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-slow")
+		.unwrap();
 
 	// Test: Include only fast-solver - should only call fast adapter
 	let mut request = ApiFixtures::valid_quote_request();
@@ -1156,9 +1162,18 @@ async fn test_solver_exclusion_filtering_behavior() {
 		.expect("Failed to start test server");
 	let client = Client::new();
 
-	let fast_adapter = adapters.iter().find(|a| a.id == "timing-fast").unwrap();
-	let slow_adapter = adapters.iter().find(|a| a.id == "timing-slow").unwrap();
-	let timeout_adapter = adapters.iter().find(|a| a.id == "timing-timeout").unwrap();
+	let fast_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-fast")
+		.unwrap();
+	let slow_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-slow")
+		.unwrap();
+	let timeout_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-timeout")
+		.unwrap();
 
 	// Test: Exclude timeout and failing solvers - should only call fast and slow
 	let mut request = ApiFixtures::valid_quote_request();
@@ -1282,8 +1297,14 @@ async fn test_timeout_behavior_verification() {
 		.expect("Failed to start test server");
 	let client = Client::new();
 
-	let fast_adapter = adapters.iter().find(|a| a.id == "timing-fast").unwrap();
-	let slow_adapter = adapters.iter().find(|a| a.id == "timing-slow").unwrap();
+	let fast_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-fast")
+		.unwrap();
+	let slow_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-slow")
+		.unwrap();
 
 	// Test: Short solver timeout (500ms) should allow fast but timeout slow
 	let mut request = ApiFixtures::valid_quote_request();
@@ -1393,7 +1414,10 @@ async fn test_early_termination_with_min_quotes() {
 		.expect("Failed to start test server");
 	let client = Client::new();
 
-	let fast_adapter = adapters.iter().find(|a| a.id == "timing-fast").unwrap();
+	let fast_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-fast")
+		.unwrap();
 
 	// Test: Include all but set minQuotes to 1 - should terminate early when fast responds
 	let mut request = ApiFixtures::valid_quote_request();
@@ -1502,7 +1526,10 @@ async fn test_global_timeout_enforcement() {
 		.expect("Failed to start test server");
 	let client = Client::new();
 
-	let _timeout_adapter = adapters.iter().find(|a| a.id == "timing-timeout").unwrap();
+	let _timeout_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-timeout")
+		.unwrap();
 
 	// Test: Short global timeout should cut off before very slow solvers respond
 	let mut request = ApiFixtures::valid_quote_request();
@@ -1599,9 +1626,18 @@ async fn test_mixed_solver_performance_scenario() {
 		.expect("Failed to start test server");
 	let client = Client::new();
 
-	let fast_adapter = adapters.iter().find(|a| a.id == "timing-fast").unwrap();
-	let slow_adapter = adapters.iter().find(|a| a.id == "timing-slow").unwrap();
-	let failing_adapter = adapters.iter().find(|a| a.id == "timing-failing").unwrap();
+	let fast_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-fast")
+		.unwrap();
+	let slow_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-slow")
+		.unwrap();
+	let failing_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-failing")
+		.unwrap();
 
 	// Test: Complex scenario with multiple solver types
 	let mut request = ApiFixtures::valid_quote_request();
@@ -1751,8 +1787,14 @@ async fn test_comprehensive_timing_verification() {
 		.expect("Failed to start test server");
 	let client = Client::new();
 
-	let fast_adapter = adapters.iter().find(|a| a.id == "timing-fast").unwrap();
-	let slow_adapter = adapters.iter().find(|a| a.id == "timing-slow").unwrap();
+	let fast_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-fast")
+		.unwrap();
+	let slow_adapter = adapters
+		.iter()
+		.find(|a| a.adapter.adapter_id == "timing-slow")
+		.unwrap();
 
 	// Test multiple scenarios and verify timing behavior
 


### PR DESCRIPTION
# Summary

This PR will:
- Add Across adapter
- Add across example
- Simplify adapter trait
- Aggregator service improvements
- Add support for routes and assets definitions to support different adapters and services

Note: Across order submission is not supported as this logic is part of across FE sdk and not supported by API. This will be supported by FE app in the future.

Closes #23 

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
