### PR TITLE
shows order type 3009 or permit-2

### DIFF
--- a/crates/types/src/orders/response.rs
+++ b/crates/types/src/orders/response.rs
@@ -41,6 +41,9 @@ pub struct OrderResponse {
 	/// Output amount
 	pub output_amounts: Vec<AssetAmount>,
 
+	/// Order type (e.g., "oif-escrow-v0", "oif-3009-v0", "oif-resource-lock-v0")
+	pub order_type: String,
+
 	/// Settlement information
 	pub settlement: Settlement,
 
@@ -145,6 +148,7 @@ impl TryFrom<&Order> for OrderResponse {
 			updated_at: order.updated_at(),
 			input_amounts: order.input_amounts().to_vec(),
 			output_amounts: order.output_amounts().to_vec(),
+			order_type: order.order_type().to_string(),
 			settlement: order.settlement().clone(),
 			fill_transaction: order.fill_transaction().cloned(),
 		})

--- a/demo/src/components/OrderStatus.tsx
+++ b/demo/src/components/OrderStatus.tsx
@@ -468,7 +468,7 @@ export default function OrderStatus({ order, onStartOver, onOrderUpdate }: Order
           <h3 className="mb-3 text-lg font-semibold text-slate-900 dark:text-white">Settlement</h3>
           <div className="p-4 rounded-lg border bg-slate-100 dark:bg-slate-900 border-slate-300 dark:border-slate-700">
             <p className="mb-2 text-sm text-slate-600 dark:text-slate-400">
-              Type: <span className="font-medium text-slate-900 dark:text-white">{order.settlement.type}</span>
+              Type: <span className="font-medium text-slate-900 dark:text-white">{order.orderType}</span>
             </p>
             <details className="text-sm">
               <summary className="cursor-pointer text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white">Settlement Data (JSON)</summary>

--- a/demo/src/types/api.ts
+++ b/demo/src/types/api.ts
@@ -132,6 +132,7 @@ export interface OrderResponse {
   updatedAt: string;
   inputAmounts: AssetAmount[];
   outputAmounts: AssetAmount[];
+  orderType: string;
   settlement: Settlement;
   quoteId?: string;
   fillTransaction?: unknown;


### PR DESCRIPTION
Simply shows the Order type on the UX:

before it said only: 'type escrow'

<img width="1151" height="741" alt="image" src="https://github.com/user-attachments/assets/bc33be23-73e4-45f1-8bd8-e66c0428e762" />
